### PR TITLE
Added xinetd to the install list

### DIFF
--- a/Scripts/Install/Ubuntu/autoInstaller.sh
+++ b/Scripts/Install/Ubuntu/autoInstaller.sh
@@ -140,8 +140,7 @@ export DEBIAN_FRONTEND="noninteractive"
 echo "Updating operating system"
 apt-get update -qq > /dev/null
 apt-get update -qq > /dev/null
-apt-get install -qq -y build-essential cmake-curses-gui git dos2unix daemon > /dev/null
-
+apt-get install -qq -y build-essential cmake-curses-gui git dos2unix daemon xinetd > /dev/null
 # Clone repos
 cd /usr/local/src
 git clone -q https://github.com/OSEHRA/VistA -b dashboard VistA-Dashboard


### PR DESCRIPTION
Some symlinks failed because my machine didn't have xinetd

It was run on a Ubuntu server - the command where it fails is somewhere after the OS update I believe, this should fix it.