### PR TITLE
Add required patch for PCE Standardization 1.0

### DIFF
--- a/Packages/Kernel/Patches/XU_8.0_672/XU-8_SEQ-546_PAT-672.kids
+++ b/Packages/Kernel/Patches/XU_8.0_672/XU-8_SEQ-546_PAT-672.kids
@@ -1,0 +1,6971 @@
+Released XU*8*672 SEQ #546
+Extracted from mail message
+**KIDS**:XU*8.0*672^
+
+**INSTALL NAME**
+XU*8.0*672
+"BLD",1583,0)
+XU*8.0*672^KERNEL^0^3180924^y
+"BLD",1583,1,0)
+^^1^1^3180605^^
+"BLD",1583,1,1,0)
+Please see the description on Forum
+"BLD",1583,4,0)
+^9.64PA^9.6^3
+"BLD",1583,4,9.4,0)
+9.4
+"BLD",1583,4,9.4,2,0)
+^9.641^9.4^1
+"BLD",1583,4,9.4,2,9.4,0)
+PACKAGE  (File-top level)
+"BLD",1583,4,9.4,2,9.4,1,0)
+^9.6411^.01^1
+"BLD",1583,4,9.4,2,9.4,1,.01,0)
+NAME
+"BLD",1583,4,9.4,222)
+y^n^p^^^^n^^n
+"BLD",1583,4,9.4,224)
+
+"BLD",1583,4,9.6,0)
+9.6
+"BLD",1583,4,9.6,2,0)
+^9.641^9.6^1
+"BLD",1583,4,9.6,2,9.6,0)
+BUILD  (File-top level)
+"BLD",1583,4,9.6,2,9.6,1,0)
+^9.6411^913.1^1
+"BLD",1583,4,9.6,2,9.6,1,913.1,0)
+DELETE ENV ROUTINE
+"BLD",1583,4,9.6,222)
+y^n^p^^^^n^^n
+"BLD",1583,4,9.6,224)
+
+"BLD",1583,4,19,0)
+19
+"BLD",1583,4,19,2,0)
+^9.641^19^1
+"BLD",1583,4,19,2,19,0)
+OPTION  (File-top level)
+"BLD",1583,4,19,2,19,1,0)
+^9.6411^82^1
+"BLD",1583,4,19,2,19,1,82,0)
+DIQ(0)
+"BLD",1583,4,19,222)
+y^n^p^^^^n^^n
+"BLD",1583,4,19,224)
+
+"BLD",1583,4,"APDD",9.4,9.4)
+
+"BLD",1583,4,"APDD",9.4,9.4,.01)
+
+"BLD",1583,4,"APDD",9.6,9.6)
+
+"BLD",1583,4,"APDD",9.6,9.6,913.1)
+
+"BLD",1583,4,"APDD",19,19)
+
+"BLD",1583,4,"APDD",19,19,82)
+
+"BLD",1583,4,"B",9.4,9.4)
+
+"BLD",1583,4,"B",9.6,9.6)
+
+"BLD",1583,4,"B",19,19)
+
+"BLD",1583,6)
+3^
+"BLD",1583,6.3)
+28
+"BLD",1583,"ABPKG")
+n
+"BLD",1583,"INID")
+y^y
+"BLD",1583,"INIT")
+XU8P672
+"BLD",1583,"KRN",0)
+^9.67PA^9002226^22
+"BLD",1583,"KRN",.4,0)
+.4
+"BLD",1583,"KRN",.401,0)
+.401
+"BLD",1583,"KRN",.402,0)
+.402
+"BLD",1583,"KRN",.403,0)
+.403
+"BLD",1583,"KRN",.403,"NM",0)
+^9.68A^1^1
+"BLD",1583,"KRN",.403,"NM",1,0)
+XPD EDIT BUILD    FILE #9.6^9.6^0
+"BLD",1583,"KRN",.403,"NM","B","XPD EDIT BUILD    FILE #9.6",1)
+
+"BLD",1583,"KRN",.5,0)
+.5
+"BLD",1583,"KRN",.84,0)
+.84
+"BLD",1583,"KRN",3.6,0)
+3.6
+"BLD",1583,"KRN",3.8,0)
+3.8
+"BLD",1583,"KRN",9.2,0)
+9.2
+"BLD",1583,"KRN",9.8,0)
+9.8
+"BLD",1583,"KRN",9.8,"NM",0)
+^9.68A^20^20
+"BLD",1583,"KRN",9.8,"NM",1,0)
+XPDIGP^^0^B15378428
+"BLD",1583,"KRN",9.8,"NM",2,0)
+XPDMENU^^0^B5326422
+"BLD",1583,"KRN",9.8,"NM",3,0)
+XPDIA3^^0^B12998832
+"BLD",1583,"KRN",9.8,"NM",4,0)
+XPDIJ^^0^B25041581
+"BLD",1583,"KRN",9.8,"NM",5,0)
+XPDIST^^0^B18736775
+"BLD",1583,"KRN",9.8,"NM",6,0)
+XPDIP^^0^B36820171
+"BLD",1583,"KRN",9.8,"NM",7,0)
+XPDTC^^0^B46881298
+"BLD",1583,"KRN",9.8,"NM",8,0)
+XPDE^^0^B49613954
+"BLD",1583,"KRN",9.8,"NM",9,0)
+XPDTA2^^0^B18380713
+"BLD",1583,"KRN",9.8,"NM",10,0)
+XPDET^^0^B36528246
+"BLD",1583,"KRN",9.8,"NM",11,0)
+XPDIA0^^0^B34838028
+"BLD",1583,"KRN",9.8,"NM",12,0)
+XPDT^^0^B64186009
+"BLD",1583,"KRN",9.8,"NM",13,0)
+XPDUTL^^0^B24086795
+"BLD",1583,"KRN",9.8,"NM",14,0)
+XPDIL^^0^B21561860
+"BLD",1583,"KRN",9.8,"NM",15,0)
+XPDIA1^^0^B73300100
+"BLD",1583,"KRN",9.8,"NM",16,0)
+XPDIA^^0^B57775447
+"BLD",1583,"KRN",9.8,"NM",17,0)
+XPDIK^^0^B45151148
+"BLD",1583,"KRN",9.8,"NM",18,0)
+XQ1^^0^B38427673
+"BLD",1583,"KRN",9.8,"NM",19,0)
+XU8P672^^0^B2195161
+"BLD",1583,"KRN",9.8,"NM",20,0)
+XU8P672E^^0^B7918706
+"BLD",1583,"KRN",9.8,"NM","B","XPDE",8)
+
+"BLD",1583,"KRN",9.8,"NM","B","XPDET",10)
+
+"BLD",1583,"KRN",9.8,"NM","B","XPDIA",16)
+
+"BLD",1583,"KRN",9.8,"NM","B","XPDIA0",11)
+
+"BLD",1583,"KRN",9.8,"NM","B","XPDIA1",15)
+
+"BLD",1583,"KRN",9.8,"NM","B","XPDIA3",3)
+
+"BLD",1583,"KRN",9.8,"NM","B","XPDIGP",1)
+
+"BLD",1583,"KRN",9.8,"NM","B","XPDIJ",4)
+
+"BLD",1583,"KRN",9.8,"NM","B","XPDIK",17)
+
+"BLD",1583,"KRN",9.8,"NM","B","XPDIL",14)
+
+"BLD",1583,"KRN",9.8,"NM","B","XPDIP",6)
+
+"BLD",1583,"KRN",9.8,"NM","B","XPDIST",5)
+
+"BLD",1583,"KRN",9.8,"NM","B","XPDMENU",2)
+
+"BLD",1583,"KRN",9.8,"NM","B","XPDT",12)
+
+"BLD",1583,"KRN",9.8,"NM","B","XPDTA2",9)
+
+"BLD",1583,"KRN",9.8,"NM","B","XPDTC",7)
+
+"BLD",1583,"KRN",9.8,"NM","B","XPDUTL",13)
+
+"BLD",1583,"KRN",9.8,"NM","B","XQ1",18)
+
+"BLD",1583,"KRN",9.8,"NM","B","XU8P672",19)
+
+"BLD",1583,"KRN",9.8,"NM","B","XU8P672E",20)
+
+"BLD",1583,"KRN",19,0)
+19
+"BLD",1583,"KRN",19,"NM",0)
+^9.68A^^
+"BLD",1583,"KRN",19.1,0)
+19.1
+"BLD",1583,"KRN",101,0)
+101
+"BLD",1583,"KRN",409.61,0)
+409.61
+"BLD",1583,"KRN",771,0)
+771
+"BLD",1583,"KRN",779.2,0)
+779.2
+"BLD",1583,"KRN",870,0)
+870
+"BLD",1583,"KRN",8989.51,0)
+8989.51
+"BLD",1583,"KRN",8989.52,0)
+8989.52
+"BLD",1583,"KRN",8993,0)
+8993
+"BLD",1583,"KRN",8994,0)
+8994
+"BLD",1583,"KRN",9002226,0)
+9002226
+"BLD",1583,"KRN","B",.4,.4)
+
+"BLD",1583,"KRN","B",.401,.401)
+
+"BLD",1583,"KRN","B",.402,.402)
+
+"BLD",1583,"KRN","B",.403,.403)
+
+"BLD",1583,"KRN","B",.5,.5)
+
+"BLD",1583,"KRN","B",.84,.84)
+
+"BLD",1583,"KRN","B",3.6,3.6)
+
+"BLD",1583,"KRN","B",3.8,3.8)
+
+"BLD",1583,"KRN","B",9.2,9.2)
+
+"BLD",1583,"KRN","B",9.8,9.8)
+
+"BLD",1583,"KRN","B",19,19)
+
+"BLD",1583,"KRN","B",19.1,19.1)
+
+"BLD",1583,"KRN","B",101,101)
+
+"BLD",1583,"KRN","B",409.61,409.61)
+
+"BLD",1583,"KRN","B",771,771)
+
+"BLD",1583,"KRN","B",779.2,779.2)
+
+"BLD",1583,"KRN","B",870,870)
+
+"BLD",1583,"KRN","B",8989.51,8989.51)
+
+"BLD",1583,"KRN","B",8989.52,8989.52)
+
+"BLD",1583,"KRN","B",8993,8993)
+
+"BLD",1583,"KRN","B",8994,8994)
+
+"BLD",1583,"KRN","B",9002226,9002226)
+
+"BLD",1583,"PRE")
+XU8P672E
+"BLD",1583,"QDEF")
+^^^^NO^^^^NO^^NO
+"BLD",1583,"QUES",0)
+^9.62^^
+"BLD",1583,"REQB",0)
+^9.611^2^2
+"BLD",1583,"REQB",1,0)
+XU*8.0*547^0
+"BLD",1583,"REQB",2,0)
+XU*8.0*559^0
+"BLD",1583,"REQB","B","XU*8.0*547",1)
+
+"BLD",1583,"REQB","B","XU*8.0*559",2)
+
+"FIA",9.4)
+PACKAGE
+"FIA",9.4,0)
+^DIC(9.4,
+"FIA",9.4,0,0)
+9.4I
+"FIA",9.4,0,1)
+y^n^p^^^^n^^n
+"FIA",9.4,0,10)
+
+"FIA",9.4,0,11)
+
+"FIA",9.4,0,"RLRO")
+
+"FIA",9.4,0,"VR")
+8.0^XU
+"FIA",9.4,9.4)
+1
+"FIA",9.4,9.4,.01)
+
+"FIA",9.6)
+BUILD
+"FIA",9.6,0)
+^XPD(9.6,
+"FIA",9.6,0,0)
+9.6I
+"FIA",9.6,0,1)
+y^n^p^^^^n^^n
+"FIA",9.6,0,10)
+
+"FIA",9.6,0,11)
+
+"FIA",9.6,0,"RLRO")
+
+"FIA",9.6,0,"VR")
+8.0^XU
+"FIA",9.6,9.6)
+1
+"FIA",9.6,9.6,913.1)
+
+"FIA",19)
+OPTION
+"FIA",19,0)
+^DIC(19,
+"FIA",19,0,0)
+19I
+"FIA",19,0,1)
+y^n^p^^^^n^^n
+"FIA",19,0,10)
+
+"FIA",19,0,11)
+
+"FIA",19,0,"RLRO")
+
+"FIA",19,0,"VR")
+8.0^XU
+"FIA",19,19)
+1
+"FIA",19,19,82)
+
+"INIT")
+XU8P672
+"KRN",.403,1,-1)
+0^1
+"KRN",.403,1,0)
+XPD EDIT BUILD^#^^^2931104^^^9.6^0^0^1
+"KRN",.403,1,40,0)
+^.4031I^17^15
+"KRN",.403,1,40,1,0)
+1^^1,1^4^17
+"KRN",.403,1,40,1,1)
+Page 1
+"KRN",.403,1,40,1,40,0)
+^.4032PI^2^2
+"KRN",.403,1,40,1,40,1,0)
+XPD EDIT BUILD HDR^1^1,1^d
+"KRN",.403,1,40,1,40,2,0)
+XPD EDIT BUILD1^2^1,1^e
+"KRN",.403,1,40,2,0)
+2^^1,1^14^4
+"KRN",.403,1,40,2,1)
+Page 2
+"KRN",.403,1,40,2,12)
+
+"KRN",.403,1,40,2,40,0)
+^.4032PI^13^3
+"KRN",.403,1,40,2,40,1,0)
+XPD EDIT BUILD HDR^1^1,1^d
+"KRN",.403,1,40,2,40,3,0)
+XPD EDIT BUILD2^2^1,1^e
+"KRN",.403,1,40,2,40,13,0)
+XPD EDIT BUILD30^3^5,1^e
+"KRN",.403,1,40,2,40,13,2)
+12^^f^1
+"KRN",.403,1,40,3,0)
+3^^5,1^^^1^17,79
+"KRN",.403,1,40,3,1)
+Kernel File^1,3,2
+"KRN",.403,1,40,3,40,0)
+^.4032PI^9^2
+"KRN",.403,1,40,3,40,4,0)
+XPD EDIT BUILD3^1^3,2^e
+"KRN",.403,1,40,3,40,4,2)
+9^^n
+"KRN",.403,1,40,3,40,9,0)
+XPD EDIT BUILD31^2^1,2^d
+"KRN",.403,1,40,4,0)
+4^^1,1^2^1
+"KRN",.403,1,40,4,1)
+File^
+"KRN",.403,1,40,4,40,0)
+^.4032PI^15^3
+"KRN",.403,1,40,4,40,1,0)
+XPD EDIT BUILD HDR^1^1,1^d
+"KRN",.403,1,40,4,40,14,0)
+XPD EDIT BUILD40^2^5,1^e
+"KRN",.403,1,40,4,40,14,2)
+12^^n
+"KRN",.403,1,40,4,40,15,0)
+XPD EDIT BUILD41^3^1,1^d
+"KRN",.403,1,40,7,0)
+7^^5,1^^^1^17,78
+"KRN",.403,1,40,7,1)
+Entries^
+"KRN",.403,1,40,7,40,0)
+^.4032PI^5^1
+"KRN",.403,1,40,7,40,5,0)
+XPD EDIT BUILD4^2^1,1^e
+"KRN",.403,1,40,8,0)
+8^^5,2^^^1^15,78
+"KRN",.403,1,40,8,1)
+Package file
+"KRN",.403,1,40,8,11)
+
+"KRN",.403,1,40,8,40,0)
+^.4032PI^23^2
+"KRN",.403,1,40,8,40,10,0)
+XPD EDIT BUILD8^3^8,2^e
+"KRN",.403,1,40,8,40,23,0)
+XPD EDIT BUILD60^4^1,2^d
+"KRN",.403,1,40,9,0)
+9^^4,3^^^1^16,77
+"KRN",.403,1,40,9,1)
+Page 9
+"KRN",.403,1,40,9,12)
+
+"KRN",.403,1,40,9,40,0)
+^.4032PI^24^2
+"KRN",.403,1,40,9,40,11,0)
+XPD EDIT BUILD9^1^1,2^e
+"KRN",.403,1,40,9,40,24,0)
+XPD EDIT BUILD9A^2^8,2^e
+"KRN",.403,1,40,9,40,24,2)
+4
+"KRN",.403,1,40,10,0)
+10^^5,4^^^1^9,76
+"KRN",.403,1,40,10,1)
+A/B namespace^
+"KRN",.403,1,40,10,11)
+
+"KRN",.403,1,40,10,12)
+
+"KRN",.403,1,40,10,40,0)
+^.4032PI^25^2
+"KRN",.403,1,40,10,40,12,0)
+XPD EDIT BUILD10^1^1,3^e
+"KRN",.403,1,40,10,40,25,0)
+XPD EDIT BUILD10A^2^2,2^e
+"KRN",.403,1,40,10,40,25,2)
+2
+"KRN",.403,1,40,11,0)
+11^^6,2^^^1^16,77
+"KRN",.403,1,40,11,1)
+Sub DD
+"KRN",.403,1,40,11,40,0)
+^.4032PI^18^2
+"KRN",.403,1,40,11,40,16,0)
+XPD EDIT BUILD42^1^2,3^e
+"KRN",.403,1,40,11,40,16,2)
+6^!IEN^n^^
+"KRN",.403,1,40,11,40,18,0)
+XPD EDIT BUILD44^2^1,3^d
+"KRN",.403,1,40,12,0)
+12^^7,3^^^1^15,76
+"KRN",.403,1,40,12,1)
+Sub Field
+"KRN",.403,1,40,12,40,0)
+^.4032PI^19^2
+"KRN",.403,1,40,12,40,17,0)
+XPD EDIT BUILD43^1^2,3^e
+"KRN",.403,1,40,12,40,17,2)
+6^!IEN^n
+"KRN",.403,1,40,12,40,19,0)
+XPD EDIT BUILD45^2^1,2^d
+"KRN",.403,1,40,13,0)
+13^^6,2^^^1^16,77
+"KRN",.403,1,40,13,1)
+Page 13
+"KRN",.403,1,40,13,40,0)
+^.4032PI^20^1
+"KRN",.403,1,40,13,40,20,0)
+XPD EDIT BUILD46^1^1,1^e
+"KRN",.403,1,40,14,0)
+14^^1,1^17^2
+"KRN",.403,1,40,14,1)
+Page 14
+"KRN",.403,1,40,14,40,0)
+^.4032PI^65^4
+"KRN",.403,1,40,14,40,1,0)
+XPD EDIT BUILD HDR^1^1,1^d
+"KRN",.403,1,40,14,40,21,0)
+XPD EDIT BUILD11^4^1,1^e
+"KRN",.403,1,40,14,40,22,0)
+XPD EDIT BUILD12^2^5,1^e
+"KRN",.403,1,40,14,40,22,2)
+4^^n
+"KRN",.403,1,40,14,40,65,0)
+XPD EDIT BUILD52^3^10,1^e
+"KRN",.403,1,40,14,40,65,2)
+4
+"KRN",.403,1,40,15,0)
+15^^2,1^^^1^17,79
+"KRN",.403,1,40,15,1)
+Install questions
+"KRN",.403,1,40,15,40,0)
+^.4032PI^8^1
+"KRN",.403,1,40,15,40,8,0)
+XPD EDIT BUILD7^1^1,1^e
+"KRN",.403,1,40,16,0)
+16^XPD EDIT BUILD HDR^1,1
+"KRN",.403,1,40,16,1)
+Page 16
+"KRN",.403,1,40,17,0)
+17^^1,1^1^14
+"KRN",.403,1,40,17,1)
+Page 17
+"KRN",.403,1,40,17,15,0)
+^^1^1^3070620^
+"KRN",.403,1,40,17,15,1,0)
+This is the page to edit the KIDS install QUESTIONS default values.
+"KRN",.403,1,40,17,40,0)
+^.4032IP^218^2
+"KRN",.403,1,40,17,40,1,0)
+XPD EDIT BUILD HDR^1^1,1^e
+"KRN",.403,1,40,17,40,218,0)
+XPD EDIT BUILD5D^2^1,1^e
+"KRN",.404,1,0)
+XPD EDIT BUILD HDR^9.6
+"KRN",.404,1,40,0)
+^.4044I^5^5
+"KRN",.404,1,40,1,0)
+1^Edit a Build^1^
+"KRN",.404,1,40,1,2)
+^^1,28^
+"KRN",.404,1,40,2,0)
+7^Name^3^
+"KRN",.404,1,40,2,1)
+.01
+"KRN",.404,1,40,2,2)
+2,7^30^2,1
+"KRN",.404,1,40,2,4)
+^^^1
+"KRN",.404,1,40,3,0)
+3^PAGE   OF 5^1^
+"KRN",.404,1,40,3,2)
+^^1,66
+"KRN",.404,1,40,4,0)
+4^!M^1^
+"KRN",.404,1,40,4,.1)
+S $P(Y,"-",80)=""
+"KRN",.404,1,40,4,2)
+^^3,1^
+"KRN",.404,1,40,5,0)
+8^TYPE^3
+"KRN",.404,1,40,5,1)
+2
+"KRN",.404,1,40,5,2)
+2,51^14^2,45
+"KRN",.404,1,40,5,4)
+^^^1
+"KRN",.404,2,0)
+XPD EDIT BUILD1^9.6
+"KRN",.404,2,12)
+
+"KRN",.404,2,40,0)
+^.4044I^19^13
+"KRN",.404,2,40,1,0)
+2^Name^3^
+"KRN",.404,2,40,1,1)
+.01
+"KRN",.404,2,40,1,2)
+5,29^50^5,23
+"KRN",.404,2,40,5,0)
+5^Environment Check Routine^3^
+"KRN",.404,2,40,5,1)
+913
+"KRN",.404,2,40,5,2)
+11,29^8^11,2
+"KRN",.404,2,40,6,0)
+7^Post-Install Routine^3^
+"KRN",.404,2,40,6,1)
+914
+"KRN",.404,2,40,6,2)
+15,29^17^15,7
+"KRN",.404,2,40,7,0)
+6^Pre-Install Routine^3^
+"KRN",.404,2,40,7,1)
+916
+"KRN",.404,2,40,7,2)
+13,29^17^13,8
+"KRN",.404,2,40,11,0)
+4^Description^3^
+"KRN",.404,2,40,11,1)
+3
+"KRN",.404,2,40,11,2)
+9,29^1^9,16
+"KRN",.404,2,40,12,0)
+1^1^1^
+"KRN",.404,2,40,12,2)
+^^1,71^
+"KRN",.404,2,40,13,0)
+3^Date Distributed^3
+"KRN",.404,2,40,13,1)
+.02
+"KRN",.404,2,40,13,2)
+7,29^11^7,11
+"KRN",.404,2,40,14,0)
+8^Pre-Transportation Routine^3
+"KRN",.404,2,40,14,1)
+900
+"KRN",.404,2,40,14,2)
+17,29^17^17,1
+"KRN",.404,2,40,15,0)
+11^Delete Routine^1
+"KRN",.404,2,40,15,2)
+^^9,57
+"KRN",.404,2,40,16,0)
+12^after install^1
+"KRN",.404,2,40,16,2)
+^^10,58
+"KRN",.404,2,40,17,0)
+13^Y/N^3
+"KRN",.404,2,40,17,1)
+913.1
+"KRN",.404,2,40,17,2)
+11,64^1^11,59
+"KRN",.404,2,40,17,11)
+N % S %(1)="Be VERY careful setting this to yes" D HLP^DDSUTL(.%)
+"KRN",.404,2,40,18,0)
+14^Y/N^3
+"KRN",.404,2,40,18,1)
+916.1
+"KRN",.404,2,40,18,2)
+13,64^1^13,59
+"KRN",.404,2,40,18,11)
+N % S %(1)="Be VERY careful setting this to yes" D HLP^DDSUTL(.%)
+"KRN",.404,2,40,19,0)
+15^Y/N^3
+"KRN",.404,2,40,19,1)
+914.1
+"KRN",.404,2,40,19,2)
+15,64^1^15,59
+"KRN",.404,2,40,19,11)
+N % S %(1)="Be VERY careful setting this to yes" D HLP^DDSUTL(.%)
+"KRN",.404,3,0)
+XPD EDIT BUILD2^9.6
+"KRN",.404,3,12)
+
+"KRN",.404,3,40,0)
+^.4044I^2^2
+"KRN",.404,3,40,1,0)
+99^3^1^
+"KRN",.404,3,40,1,2)
+^^1,71^
+"KRN",.404,3,40,2,0)
+2^Build Components^1^
+"KRN",.404,3,40,2,2)
+^^4,28^1
+"KRN",.404,4,0)
+XPD EDIT BUILD3^9.68
+"KRN",.404,4,40,0)
+^.4044I^2^2
+"KRN",.404,4,40,1,0)
+1^^3^
+"KRN",.404,4,40,1,1)
+.01
+"KRN",.404,4,40,1,2)
+1,2^45
+"KRN",.404,4,40,2,0)
+2^^3
+"KRN",.404,4,40,2,1)
+.03
+"KRN",.404,4,40,2,2)
+1,50^26
+"KRN",.404,4,40,2,3)
+SEND TO SITE
+"KRN",.404,4,40,2,4)
+1
+"KRN",.404,5,0)
+XPD EDIT BUILD4^9.64
+"KRN",.404,5,40,0)
+^.4044I^18^7
+"KRN",.404,5,40,1,0)
+1^ DD Export Options ^1^
+"KRN",.404,5,40,1,2)
+^^1,27^1
+"KRN",.404,5,40,2,0)
+2^File^3^
+"KRN",.404,5,40,2,1)
+.01
+"KRN",.404,5,40,2,2)
+3,30^45^3,24
+"KRN",.404,5,40,7,0)
+7^Data Comes With File...^3^
+"KRN",.404,5,40,7,1)
+222.7
+"KRN",.404,5,40,7,2)
+12,33^3^12,8
+"KRN",.404,5,40,7,3)
+NO
+"KRN",.404,5,40,7,10)
+S:X="y" DDSSTACK=13
+"KRN",.404,5,40,7,13)
+D:X="y" PUT^DDSVAL(DIE,.DA,222.3,"f","","I")
+"KRN",.404,5,40,13,0)
+6^Screen to Determine DD Update^3
+"KRN",.404,5,40,13,1)
+223
+"KRN",.404,5,40,13,2)
+10,2^76^9,2^1
+"KRN",.404,5,40,14,0)
+5^Send Security Code^3
+"KRN",.404,5,40,14,1)
+222.2
+"KRN",.404,5,40,14,2)
+7,62^3^7,42
+"KRN",.404,5,40,14,3)
+YES
+"KRN",.404,5,40,16,0)
+4^Update the Data Dictionary^3
+"KRN",.404,5,40,16,1)
+222.1
+"KRN",.404,5,40,16,2)
+7,30^3^7,2
+"KRN",.404,5,40,16,3)
+YES
+"KRN",.404,5,40,18,0)
+3^Send Full or Partial DD...^3
+"KRN",.404,5,40,18,1)
+222.3
+"KRN",.404,5,40,18,2)
+5,33^7^5,5
+"KRN",.404,5,40,18,3)
+FULL
+"KRN",.404,5,40,18,10)
+S:X="p" DDSSTACK=11
+"KRN",.404,5,40,18,13)
+D:X="p" PAR964^XPDET
+"KRN",.404,8,0)
+XPD EDIT BUILD7^9.62
+"KRN",.404,8,40,0)
+^.4044I^10^10
+"KRN",.404,8,40,1,0)
+2^Name^3^
+"KRN",.404,8,40,1,1)
+.01
+"KRN",.404,8,40,1,2)
+2,12^30^2,6
+"KRN",.404,8,40,2,0)
+3^DIR(0)^3^
+"KRN",.404,8,40,2,1)
+1
+"KRN",.404,8,40,2,2)
+4,12^65^4,4
+"KRN",.404,8,40,3,0)
+4^DIR(A)^3^
+"KRN",.404,8,40,3,1)
+2
+"KRN",.404,8,40,3,2)
+6,12^65^6,4
+"KRN",.404,8,40,4,0)
+5^DIR(A,#)^3^
+"KRN",.404,8,40,4,1)
+3
+"KRN",.404,8,40,4,2)
+7,12^1^7,2
+"KRN",.404,8,40,5,0)
+6^DIR(B)^3^
+"KRN",.404,8,40,5,1)
+4
+"KRN",.404,8,40,5,2)
+9,12^65^9,4
+"KRN",.404,8,40,6,0)
+7^DIR(?)^3^
+"KRN",.404,8,40,6,1)
+5
+"KRN",.404,8,40,6,2)
+11,12^65^11,4
+"KRN",.404,8,40,7,0)
+8^DIR(?,#)^3^
+"KRN",.404,8,40,7,1)
+6
+"KRN",.404,8,40,7,2)
+12,12^1^12,2
+"KRN",.404,8,40,8,0)
+9^DIR(??)^3^
+"KRN",.404,8,40,8,1)
+7
+"KRN",.404,8,40,8,2)
+13,12^64^13,3
+"KRN",.404,8,40,9,0)
+10^M Code^3
+"KRN",.404,8,40,9,1)
+10
+"KRN",.404,8,40,9,2)
+15,12^65^15,4
+"KRN",.404,8,40,10,0)
+1^ Install Questions ^1^
+"KRN",.404,8,40,10,2)
+^^1,27^1
+"KRN",.404,9,0)
+XPD EDIT BUILD31^9.67
+"KRN",.404,9,40,0)
+^.4044I^1^1
+"KRN",.404,9,40,1,0)
+1^!M^1^
+"KRN",.404,9,40,1,.1)
+S Y=" "_$P($G(^DIC(D1,0)),U)_" "
+"KRN",.404,9,40,1,2)
+^^1,27^
+"KRN",.404,10,0)
+XPD EDIT BUILD8^9.6
+"KRN",.404,10,11)
+
+"KRN",.404,10,40,0)
+^.4044I^1^1
+"KRN",.404,10,40,1,0)
+1^Alpha/Beta Testing...^3
+"KRN",.404,10,40,1,1)
+20
+"KRN",.404,10,40,1,2)
+2,31^3^2,8
+"KRN",.404,10,40,1,3)
+NO
+"KRN",.404,10,40,1,10)
+S:X="y" DDSSTACK="9"
+"KRN",.404,11,0)
+XPD EDIT BUILD9^9.6
+"KRN",.404,11,40,0)
+^.4044I^5^4
+"KRN",.404,11,40,1,0)
+2^Installation Message^3
+"KRN",.404,11,40,1,1)
+21
+"KRN",.404,11,40,1,2)
+3,30^3^3,8
+"KRN",.404,11,40,1,3)
+NO
+"KRN",.404,11,40,2,0)
+3^Address for Usage Reporting^3
+"KRN",.404,11,40,2,1)
+22
+"KRN",.404,11,40,2,2)
+5,30^44^5,1
+"KRN",.404,11,40,4,0)
+1^ Alpha/Beta Testing ^1^
+"KRN",.404,11,40,4,2)
+^^1,26^1
+"KRN",.404,11,40,5,0)
+4^Package Namespace or Prefix:^1
+"KRN",.404,11,40,5,2)
+^^7,1
+"KRN",.404,12,0)
+XPD EDIT BUILD10^9.66
+"KRN",.404,12,40,0)
+^.4044I^1^1
+"KRN",.404,12,40,1,0)
+1^ Exclude Namespace or Prefix ^1
+"KRN",.404,12,40,1,2)
+^^1,20^1
+"KRN",.404,13,0)
+XPD EDIT BUILD30^9.67
+"KRN",.404,13,40,0)
+^.4044I^2^2
+"KRN",.404,13,40,1,0)
+1^^3
+"KRN",.404,13,40,1,1)
+.01
+"KRN",.404,13,40,1,2)
+2,1^24
+"KRN",.404,13,40,1,4)
+^^^2
+"KRN",.404,13,40,1,10)
+S DDSSTACK=3
+"KRN",.404,13,40,2,0)
+2^^4
+"KRN",.404,13,40,2,2)
+2,27^5
+"KRN",.404,13,40,2,4)
+^^1
+"KRN",.404,13,40,2,30)
+S Y="("_+$P($G(^XPD(9.6,DA(1),"KRN",DA,"NM",0)),U,4)_")"
+"KRN",.404,14,0)
+XPD EDIT BUILD40^9.64
+"KRN",.404,14,40,0)
+^.4044I^1^1
+"KRN",.404,14,40,1,0)
+1^^3
+"KRN",.404,14,40,1,1)
+.01
+"KRN",.404,14,40,1,2)
+2,7^45
+"KRN",.404,14,40,1,10)
+S DDSSTACK=7
+"KRN",.404,15,0)
+XPD EDIT BUILD41^9.6
+"KRN",.404,15,40,0)
+^.4044I^3^2
+"KRN",.404,15,40,1,0)
+1^2^1^
+"KRN",.404,15,40,1,2)
+^^1,71^
+"KRN",.404,15,40,3,0)
+2^File List  (Name or Number)^1
+"KRN",.404,15,40,3,2)
+^^4,28
+"KRN",.404,16,0)
+XPD EDIT BUILD42^9.641
+"KRN",.404,16,40,0)
+^.4044I^1^1
+"KRN",.404,16,40,1,0)
+1^^3
+"KRN",.404,16,40,1,1)
+.01
+"KRN",.404,16,40,1,2)
+1,1^45
+"KRN",.404,16,40,1,10)
+S DDSSTACK=12
+"KRN",.404,17,0)
+XPD EDIT BUILD43^9.6411
+"KRN",.404,17,40,0)
+^.4044I^1^1
+"KRN",.404,17,40,1,0)
+1^^3
+"KRN",.404,17,40,1,1)
+.01
+"KRN",.404,17,40,1,2)
+1,1^45
+"KRN",.404,18,0)
+XPD EDIT BUILD44^9.64
+"KRN",.404,18,40,0)
+^.4044I^1^1
+"KRN",.404,18,40,1,0)
+1^ Data Dictionary Number ^1^
+"KRN",.404,18,40,1,2)
+^^1,24^1
+"KRN",.404,19,0)
+XPD EDIT BUILD45^9.641
+"KRN",.404,19,40,0)
+^.4044I^1^1
+"KRN",.404,19,40,1,0)
+1^ Field Number ^1^
+"KRN",.404,19,40,1,2)
+^^1,24^1
+"KRN",.404,20,0)
+XPD EDIT BUILD46^9.64
+"KRN",.404,20,40,0)
+^.4044I^7^6
+"KRN",.404,20,40,1,0)
+1^ Data Export Options ^1^
+"KRN",.404,20,40,1,2)
+^^1,29^1
+"KRN",.404,20,40,2,0)
+2^Site's Data^3
+"KRN",.404,20,40,2,1)
+222.8
+"KRN",.404,20,40,2,2)
+3,21^15^3,8
+"KRN",.404,20,40,2,3)
+OVERWRITE
+"KRN",.404,20,40,3,0)
+5^Data List^3
+"KRN",.404,20,40,3,1)
+222.6
+"KRN",.404,20,40,3,2)
+7,21^30^7,10
+"KRN",.404,20,40,4,0)
+3^Resolve Pointers^3
+"KRN",.404,20,40,4,1)
+222.5
+"KRN",.404,20,40,4,2)
+5,21^3^5,3
+"KRN",.404,20,40,4,3)
+NO
+"KRN",.404,20,40,5,0)
+4^May User Override Data Update^3
+"KRN",.404,20,40,5,1)
+222.9
+"KRN",.404,20,40,5,2)
+5,68^3^5,37
+"KRN",.404,20,40,5,3)
+NO
+"KRN",.404,20,40,7,0)
+6^Screen to Select Data^3
+"KRN",.404,20,40,7,1)
+224
+"KRN",.404,20,40,7,2)
+10,3^72^9,3^1
+"KRN",.404,21,0)
+XPD EDIT BUILD11^9.6
+"KRN",.404,21,40,0)
+^.4044I^5^5
+"KRN",.404,21,40,1,0)
+1^4^1^
+"KRN",.404,21,40,1,2)
+^^1,71^
+"KRN",.404,21,40,2,0)
+7^Package File Link...^3
+"KRN",.404,21,40,2,1)
+1
+"KRN",.404,21,40,2,2)
+15,27^30^15,5
+"KRN",.404,21,40,2,10)
+S:X]"" DDSSTACK=8
+"KRN",.404,21,40,3,0)
+8^Track Package Nationally^3
+"KRN",.404,21,40,3,1)
+5
+"KRN",.404,21,40,3,2)
+17,27^3^17,1
+"KRN",.404,21,40,3,3)
+NO
+"KRN",.404,21,40,3,11)
+S:$$GET^DDSVAL(DIE,.DA,1)="" DDSBR="^^COM"
+"KRN",.404,21,40,4,0)
+2^Install Questions^1^
+"KRN",.404,21,40,4,2)
+^^4,28^1
+"KRN",.404,21,40,5,0)
+5^Required Builds^1
+"KRN",.404,21,40,5,2)
+^^9,28
+"KRN",.404,22,0)
+XPD EDIT BUILD12^9.62
+"KRN",.404,22,40,0)
+^.4044I^1^1
+"KRN",.404,22,40,1,0)
+1^^3
+"KRN",.404,22,40,1,1)
+.01
+"KRN",.404,22,40,1,2)
+1,3^30
+"KRN",.404,22,40,1,10)
+S DDSSTACK=15
+"KRN",.404,23,0)
+XPD EDIT BUILD60^9.6
+"KRN",.404,23,40,0)
+^.4044I^3^3
+"KRN",.404,23,40,1,0)
+1^ Edit PACKAGE File ^1^
+"KRN",.404,23,40,1,2)
+^^1,26^1
+"KRN",.404,23,40,2,0)
+2^Name^3
+"KRN",.404,23,40,2,1)
+.01
+"KRN",.404,23,40,2,2)
+2,8^30^2,2
+"KRN",.404,23,40,3,0)
+3^!M^1^
+"KRN",.404,23,40,3,.1)
+S $P(Y,"-",76)=""
+"KRN",.404,23,40,3,2)
+^^3,1^
+"KRN",.404,24,0)
+XPD EDIT BUILD9A^9.66
+"KRN",.404,24,40,0)
+^.4044I^1^1
+"KRN",.404,24,40,1,0)
+1^^3
+"KRN",.404,24,40,1,1)
+.01
+"KRN",.404,24,40,1,2)
+2,2^4
+"KRN",.404,24,40,1,10)
+S DDSSTACK=10
+"KRN",.404,25,0)
+XPD EDIT BUILD10A^9.661
+"KRN",.404,25,40,0)
+^.4044I^1^1
+"KRN",.404,25,40,1,0)
+1^^3
+"KRN",.404,25,40,1,1)
+.01
+"KRN",.404,25,40,1,2)
+1,2^4
+"KRN",.404,65,0)
+XPD EDIT BUILD52^9.611
+"KRN",.404,65,40,0)
+^.4044I^2^2
+"KRN",.404,65,40,1,0)
+2^^3
+"KRN",.404,65,40,1,1)
+.01
+"KRN",.404,65,40,1,2)
+1,3^40
+"KRN",.404,65,40,2,0)
+3^^3
+"KRN",.404,65,40,2,1)
+1
+"KRN",.404,65,40,2,2)
+1,49^30
+"KRN",.404,65,40,2,4)
+1
+"KRN",.404,218,0)
+XPD EDIT BUILD5D^9.6
+"KRN",.404,218,40,0)
+^.4044I^5^5
+"KRN",.404,218,40,1,0)
+1^Rebuild Menu Tree Upon Completion^3^^XPO1
+"KRN",.404,218,40,1,1)
+51.09
+"KRN",.404,218,40,1,2)
+6,36^3^6,1
+"KRN",.404,218,40,2,0)
+2^Want KIDS to INHIBIT LOGONs^3^^XPI1
+"KRN",.404,218,40,2,1)
+51.05
+"KRN",.404,218,40,2,2)
+8,36^3^8,7
+"KRN",.404,218,40,3,0)
+3^Want to DISABLE Scheduled Options^3^^XPZ1
+"KRN",.404,218,40,3,1)
+51.11
+"KRN",.404,218,40,3,2)
+10,36^3^10,1
+"KRN",.404,218,40,4,0)
+4^Change the 'NO' defaults the sites will see when KIDS asks these questions!^1
+"KRN",.404,218,40,4,2)
+^^4,3
+"KRN",.404,218,40,5,0)
+5^5^1
+"KRN",.404,218,40,5,2)
+^^1,71
+"MBREQ")
+0
+"ORD",8,.403)
+.403;8;;;EDEOUT^DIFROMSO(.403,DA,"",XPDA);FPRE^DIFROMSI(.403,"",XPDA);EPRE^DIFROMSI(.403,DA,$E("N",$G(XPDNEW)),XPDA,"",OLDA);;EPOST^DIFROMSI(.403,DA,"",XPDA);DEL^DIFROMSK(.403,"",%)
+"ORD",8,.403,0)
+FORM
+"PKG",3,-1)
+1^1
+"PKG",3,0)
+KERNEL^XU^SIGN-ON, SECURITY, MENU DRIVER, DEVICES, TASKMAN^
+"PKG",3,22,0)
+^9.49I^1^1
+"PKG",3,22,1,0)
+8.0^3090706^3090706^6
+"PKG",3,22,1,"PAH",1,0)
+672^3180924^6
+"PKG",3,22,1,"PAH",1,1,0)
+^^1^1^3180924
+"PKG",3,22,1,"PAH",1,1,1,0)
+Please see the description on Forum
+"PRE")
+XU8P672E
+"QUES","XPF1",0)
+Y
+"QUES","XPF1","??")
+^D REP^XPDH
+"QUES","XPF1","A")
+Shall I write over your |FLAG| File
+"QUES","XPF1","B")
+YES
+"QUES","XPF1","M")
+D XPF1^XPDIQ
+"QUES","XPF2",0)
+Y
+"QUES","XPF2","??")
+^D DTA^XPDH
+"QUES","XPF2","A")
+Want my data |FLAG| yours
+"QUES","XPF2","B")
+YES
+"QUES","XPF2","M")
+D XPF2^XPDIQ
+"QUES","XPI1",0)
+YO
+"QUES","XPI1","??")
+^D INHIBIT^XPDH
+"QUES","XPI1","A")
+Want KIDS to INHIBIT LOGONs during the install
+"QUES","XPI1","B")
+NO
+"QUES","XPI1","M")
+D XPI1^XPDIQ
+"QUES","XPM1",0)
+PO^VA(200,:EM
+"QUES","XPM1","??")
+^D MG^XPDH
+"QUES","XPM1","A")
+Enter the Coordinator for Mail Group '|FLAG|'
+"QUES","XPM1","B")
+
+"QUES","XPM1","M")
+D XPM1^XPDIQ
+"QUES","XPO1",0)
+Y
+"QUES","XPO1","??")
+^D MENU^XPDH
+"QUES","XPO1","A")
+Want KIDS to Rebuild Menu Trees Upon Completion of Install
+"QUES","XPO1","B")
+NO
+"QUES","XPO1","M")
+D XPO1^XPDIQ
+"QUES","XPZ1",0)
+Y
+"QUES","XPZ1","??")
+^D OPT^XPDH
+"QUES","XPZ1","A")
+Want to DISABLE Scheduled Options, Menu Options, and Protocols
+"QUES","XPZ1","B")
+NO
+"QUES","XPZ1","M")
+D XPZ1^XPDIQ
+"QUES","XPZ2",0)
+Y
+"QUES","XPZ2","??")
+^D RTN^XPDH
+"QUES","XPZ2","A")
+Want to MOVE routines to other CPUs
+"QUES","XPZ2","B")
+NO
+"QUES","XPZ2","M")
+D XPZ2^XPDIQ
+"RTN")
+20
+"RTN","XPDE")
+0^8^B49613954^B45567472
+"RTN","XPDE",1,0)
+XPDE ;SFISC/RSD - Package Edit ;06/24/2008
+"RTN","XPDE",2,0)
+ ;;8.0;KERNEL;**2,15,21,44,51,68,131,182,201,229,302,399,507,539,672**;Jul 10, 1995;Build 28
+"RTN","XPDE",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XPDE",4,0)
+ Q
+"RTN","XPDE",5,0)
+ ;these tags are called from options.
+"RTN","XPDE",6,0)
+EDIT ;edit Build file package
+"RTN","XPDE",7,0)
+ N DA,DIR,DDSFILE,DR,Y,Z
+"RTN","XPDE",8,0)
+ Q:'$$DIC("AEMQLZ","",1)  S DA=+Y
+"RTN","XPDE",9,0)
+ I $P(Y,U,3) D NEW(DA)
+"RTN","XPDE",10,0)
+ S Z=$P(^XPD(9.6,DA,0),U,3)+1,DR="["_$P("XPD EDIT BUILD^XPD EDIT MP^XPD EDIT GP",U,Z)_"]",DDSFILE="^XPD(9.6,"
+"RTN","XPDE",11,0)
+ D ^DDS Q:'$G(DA)
+"RTN","XPDE",12,0)
+ ;if full DD, kill multiple for partial DD
+"RTN","XPDE",13,0)
+ S Y=0 F  S Y=$O(^XPD(9.6,DA,4,Y)) Q:'Y  S Z=$G(^(Y,222)) D
+"RTN","XPDE",14,0)
+ .K:$P(Z,U,3)="f" ^XPD(9.6,DA,4,Y,2),^XPD(9.6,DA,4,"APDD",Y)
+"RTN","XPDE",15,0)
+ D QUIT(DA)
+"RTN","XPDE",16,0)
+ Q
+"RTN","XPDE",17,0)
+COPY ;copy a Build file package
+"RTN","XPDE",18,0)
+ N DA,DIK,DIR,FR,FR0,TO,TO0,X,Y,Z W !
+"RTN","XPDE",19,0)
+ Q:'$$DIC("QEAMZ","Copy FROM what Package: ")
+"RTN","XPDE",20,0)
+ S FR=+Y,FR0=Y(0),Z="QEAMZL",Z("S")="I Y'="_FR
+"RTN","XPDE",21,0)
+ I '$$DIC(.Z,"Copy TO what Package: ") D QUIT(FR) Q
+"RTN","XPDE",22,0)
+ S TO=Y,TO0=Y(0)
+"RTN","XPDE",23,0)
+ ;if this is not new, then it will be purged before copy.
+"RTN","XPDE",24,0)
+ I '$P(TO,U,3) W !,$P(TO0,U)," package will be PURGED before the copy."
+"RTN","XPDE",25,0)
+ W ! S DIR(0)="Y",DIR("A")="OK to continue",DIR("B")="YES" D ^DIR
+"RTN","XPDE",26,0)
+ S DIK="^XPD(9.6,",DA=+TO
+"RTN","XPDE",27,0)
+ I 'Y!$D(DIRUT) D  W ! Q
+"RTN","XPDE",28,0)
+ .;they didn't want to continue, kill if it was a new package.
+"RTN","XPDE",29,0)
+ .I $P(TO,U,3) D ^DIK W $P(TO0,U)," being deleted!"
+"RTN","XPDE",30,0)
+ .;unlock both packages
+"RTN","XPDE",31,0)
+ .D QUIT(FR),QUIT(TO)
+"RTN","XPDE",32,0)
+ D WAIT^DICD
+"RTN","XPDE",33,0)
+ ;if not new, kill old data
+"RTN","XPDE",34,0)
+ K:'$P(TO,U,3) ^XPD(9.6,DA)
+"RTN","XPDE",35,0)
+ M ^XPD(9.6,DA)=^XPD(9.6,FR) S $P(^(DA,0),U)=$P(TO0,U)
+"RTN","XPDE",36,0)
+ D NEW(+TO)
+"RTN","XPDE",37,0)
+ ;if new National Package name, then kill x-ref
+"RTN","XPDE",38,0)
+ I $P(TO0,U,2)]"",$P(FR0,U,2)'=$P(TO0,U,2) K ^XPD(9.6,"C",$E($P(TO0,U,2),1,30),DA) S DIK(1)=1 D EN1^DIK
+"RTN","XPDE",39,0)
+ D QUIT(FR),QUIT(TO)
+"RTN","XPDE",40,0)
+ W "...Done.",!
+"RTN","XPDE",41,0)
+ Q
+"RTN","XPDE",42,0)
+BUILD ;build package from a namespace
+"RTN","XPDE",43,0)
+ N DIR,DIRUT,XPDA,XPDI,XPDF,XPDN,XPDX,XPDXL,X,X1,Y,Y1 W !
+"RTN","XPDE",44,0)
+ Q:'$$DIC("QEAML")
+"RTN","XPDE",45,0)
+ S XPDA=+Y W !
+"RTN","XPDE",46,0)
+ I $P(^XPD(9.6,XPDA,0),U,3) W !,"The Build Type must be SINGLE PACKAGE!!",! Q
+"RTN","XPDE",47,0)
+ ;if not a new package
+"RTN","XPDE",48,0)
+ I '$P(Y,U,3) D  I $D(DIRUT) D QUIT(XPDA) Q
+"RTN","XPDE",49,0)
+ .S DIR(0)="Y",DIR("A")="Package already exists, Want to PURGE the existing data",DIR("B")="NO",DIR("?")="YES will delete all the KERNEL FILE information for this package in the BUILD file."
+"RTN","XPDE",50,0)
+ .D ^DIR K DIR Q:'Y
+"RTN","XPDE",51,0)
+ .S Y=0 F  S Y=$O(^XPD(9.6,XPDA,"KRN",Y)) Q:'Y  K ^(Y,"NM")
+"RTN","XPDE",52,0)
+ E  D NEW(XPDA)
+"RTN","XPDE",53,0)
+ ;XPDN(0=excluded names or 1=include names, namespace)=""
+"RTN","XPDE",54,0)
+ W ! S DIR(0)="FO^1:15^K:X'?.1""-""1U.15UNP X",DIR("A")="Namespace",DIR("?")="Enter 1 to 15 characters, precede with ""-"" to exclude namespace"
+"RTN","XPDE",55,0)
+ F  D ^DIR Q:$D(DIRUT)  S X=$E(Y,$L(Y))="*",%=$E(Y)="-",XPDN('%,$E(Y,%+1,$L(Y)-X))=""
+"RTN","XPDE",56,0)
+ I '$D(XPDN)!$D(DTOUT)!$D(DUOUT) D QUIT(XPDA) Q
+"RTN","XPDE",57,0)
+ W !!,"NAMESPACE  INCLUDE",?35,"EXCLUDE",!,?11,"-------",?35,"-------"
+"RTN","XPDE",58,0)
+ S (X,Y)="",(X1,Y1)=1
+"RTN","XPDE",59,0)
+ F  D  W !?11,X,?35,Y Q:'X1&'Y1
+"RTN","XPDE",60,0)
+ .S:X1 X=$O(XPDN(1,X)),X1=X]"" S:Y1 Y=$O(XPDN(0,Y)),Y1=Y]""
+"RTN","XPDE",61,0)
+ S DIR(0)="Y",DIR("A")="OK to continue",DIR("B")="YES" D ^DIR
+"RTN","XPDE",62,0)
+ I 'Y!$D(DIRUT) D QUIT(XPDA) Q
+"RTN","XPDE",63,0)
+ D WAIT^DICD S XPDX="",XPDI("IEN")=0
+"RTN","XPDE",64,0)
+ F  S XPDX=$O(XPDN(1,XPDX)),XPDXL=$L(XPDX),XPDF=0 Q:XPDX=""  D
+"RTN","XPDE",65,0)
+ .F  S XPDF=$O(^XPD(9.6,XPDA,"KRN",XPDF)) Q:'XPDF  D
+"RTN","XPDE",66,0)
+ ..N XPD,XPDIC,XPDJ,XPCNT W "."
+"RTN","XPDE",67,0)
+ ..;XPDIC is used in $$SCR1^XPDET
+"RTN","XPDE",68,0)
+ ..S XPDIC="^XPD(9.6,"_XPDA_",""KRN"","_XPDF_",""NM"",",XPCNT=0
+"RTN","XPDE",69,0)
+ ..D LIST^DIC(XPDF,"","","","*",.XPDI,XPDX,"","I $E(^(0),1,XPDXL)=XPDX,$$SCR1^XPDET(Y)")
+"RTN","XPDE",70,0)
+ ..F XPDJ=1:1 S X=$G(^TMP("DILIST",$J,1,XPDJ)) Q:X=""  D
+"RTN","XPDE",71,0)
+ ...S:XPDF<.404 %=^TMP("DILIST",$J,2,XPDJ)_",",X=$$TX^XPDET(X,$$GET1^DIQ(XPDF,%,$$TF^XPDET(XPDF),"I"))
+"RTN","XPDE",72,0)
+ ...S Y="+"_XPDJ_","_XPDF_","_XPDA_",",XPD(9.68,Y,.01)=X,XPD(9.68,Y,.03)=0
+"RTN","XPDE",73,0)
+ ...;Keep XPD from getting too big.
+"RTN","XPDE",74,0)
+ ...S XPCNT=XPCNT+1 I XPCNT>100 D UPDATE^DIE("","XPD") S XPCNT=0 K XPD
+"RTN","XPDE",75,0)
+ ..Q:'$D(XPD)  D UPDATE^DIE("","XPD")
+"RTN","XPDE",76,0)
+ D QUIT(XPDA)
+"RTN","XPDE",77,0)
+ W "...Done.",!
+"RTN","XPDE",78,0)
+ Q
+"RTN","XPDE",79,0)
+VER ;verify a Build file package
+"RTN","XPDE",80,0)
+ N XPDA,Y
+"RTN","XPDE",81,0)
+ Q:'$$DIC("AEMQZ")  S XPDA=+Y
+"RTN","XPDE",82,0)
+ D EN^XPDV
+"RTN","XPDE",83,0)
+ Q
+"RTN","XPDE",84,0)
+DIC(DIC,A,XPDL) ;DIC lookup to Build file, 9.6
+"RTN","XPDE",85,0)
+ N DLAYGO
+"RTN","XPDE",86,0)
+ S DIC(0)=$G(DIC),DIC="^XPD(9.6," S:$G(A)]"" DIC("A")=A
+"RTN","XPDE",87,0)
+ S:DIC(0)["L" DLAYGO=9.6,DIC("DR")="1;2//SINGLE PACKAGE;5//YES"
+"RTN","XPDE",88,0)
+ D ^DIC Q:Y<0 0
+"RTN","XPDE",89,0)
+ I '$G(XPDL) L +^XPD(9.6,+Y):0 E  W !,"Being accessed by another user" Q 0
+"RTN","XPDE",90,0)
+ Q +Y
+"RTN","XPDE",91,0)
+ ;
+"RTN","XPDE",92,0)
+NEW(DA) ;create Kernel Files multiple for package DA
+"RTN","XPDE",93,0)
+ N I,J,X,XPDNEWF,XPD,XPDI
+"RTN","XPDE",94,0)
+ S:'$D(^XPD(9.6,DA,"KRN",0)) ^XPD(9.6,DA,"KRN",0)=U_$P(^DD(9.6,7,0),U,2)
+"RTN","XPDE",95,0)
+ S I=0
+"RTN","XPDE",96,0)
+ F J=1:1 S X=+$P($T(FILES+J),";;",2) Q:'X  S:$D(^DD(X))&'$D(^XPD(9.6,DA,"KRN",X)) I=I+1,(XPDI(I),XPD(9.67,"+"_I_","_DA_",",.01))=X
+"RTN","XPDE",97,0)
+ Q:'$D(XPD)
+"RTN","XPDE",98,0)
+ ;XPDNEWF is a flag in INPUT transform of BUILD COMPONENT multiple
+"RTN","XPDE",99,0)
+ S XPDNEWF=1
+"RTN","XPDE",100,0)
+ D UPDATE^DIE("","XPD","XPDI")
+"RTN","XPDE",101,0)
+ Q
+"RTN","XPDE",102,0)
+QUIT(Y) ;unlock Y
+"RTN","XPDE",103,0)
+ L -^XPD(9.6,Y)
+"RTN","XPDE",104,0)
+ Q
+"RTN","XPDE",105,0)
+ ;
+"RTN","XPDE",106,0)
+ ;;file;install order;x-ref;file build;entry build;file pre;entry pre;file post;entry post;delete
+"RTN","XPDE",107,0)
+ ;You must put in code to delete anything
+"RTN","XPDE",108,0)
+FILES ;kernel files for field 7 in file 9.6
+"RTN","XPDE",109,0)
+ ;;9.8;;1;RTNF^XPDTA;RTNE^XPDTA
+"RTN","XPDE",110,0)
+ ;;9.2;1;;;HELP^XPDTA1;HLPF1^XPDIA1;HLPE1^XPDIA1;HLPF2^XPDIA1;;HLPDEL^XPDIA1
+"RTN","XPDE",111,0)
+ ;;3.6;2;1;;BUL^XPDTA1;;BULE1^XPDIA1;;;BULDEL^XPDIA1
+"RTN","XPDE",112,0)
+ ;;19.1;3;;;KEY^XPDTA1;KEYF1^XPDIA1;KEYE1^XPDIA1;KEYF2^XPDIA1;;KEYDEL^XPDIA1
+"RTN","XPDE",113,0)
+ ;;.5;4;;;EDEOUT^DIFROMSO(.5,DA,"",XPDA);FPRE^DIFROMSI(.5,"",XPDA);EPRE^DIFROMSI(.5,DA,"",XPDA,"",OLDA);;EPOST^DIFROMSI(.5,DA,"",XPDA)
+"RTN","XPDE",114,0)
+ ;;.4;5;;;EDEOUT^DIFROMSO(.4,DA,"",XPDA);FPRE^DIFROMSI(.4,"",XPDA);EPRE^DIFROMSI(.4,DA,$E("N",$G(XPDNEW)),XPDA,"",OLDA);;EPOST^DIFROMSI(.4,DA,"",XPDA);DEL^DIFROMSK(.4,"",%)
+"RTN","XPDE",115,0)
+ ;;.401;6;;;EDEOUT^DIFROMSO(.401,DA,"",XPDA);FPRE^DIFROMSI(.401,"",XPDA);EPRE^DIFROMSI(.401,DA,$E("N",$G(XPDNEW)),XPDA,"",OLDA);;EPOST^DIFROMSI(.401,DA,"",XPDA);DEL^DIFROMSK(.401,"",%)
+"RTN","XPDE",116,0)
+ ;;.402;7;;;EDEOUT^DIFROMSO(.402,DA,"",XPDA);FPRE^DIFROMSI(.402,"",XPDA);EPRE^DIFROMSI(.402,DA,$E("N",$G(XPDNEW)),XPDA,"",OLDA);;EPOST^DIFROMSI(.402,DA,"",XPDA);DEL^DIFROMSK(.402,"",%)
+"RTN","XPDE",117,0)
+ ;;.403;8;;;EDEOUT^DIFROMSO(.403,DA,"",XPDA);FPRE^DIFROMSI(.403,"",XPDA);EPRE^DIFROMSI(.403,DA,$E("N",$G(XPDNEW)),XPDA,"",OLDA);;EPOST^DIFROMSI(.403,DA,"",XPDA);DEL^DIFROMSK(.403,"",%)
+"RTN","XPDE",118,0)
+ ;;.84;9;;;EDEOUT^DIFROMSO(.84,DA,"",XPDA);FPRE^DIFROMSI(.84,"",XPDA);EPRE^DIFROMSI(.84,DA,$E("N",$G(XPDNEW)),XPDA,"",OLDA);;EPOST^DIFROMSI(.84,DA,"",XPDA);DEL^DIFROMSK(.84,"",%)
+"RTN","XPDE",119,0)
+ ;;3.8;11;;;MAILG^XPDTA1;MAILGF1^XPDIA1;MAILGE1^XPDIA1;MAILGF2^XPDIA1;;MAILGDEL^XPDIA1(%)
+"RTN","XPDE",120,0)
+ ;;870;13;1;;HLLL^XPDTA1;;HLLLE^XPDIA1;;;HLLLDEL^XPDIA1(%)
+"RTN","XPDE",121,0)
+ ;;771;14;;;HLAP^XPDTA1;HLAPF1^XPDIA1;HLAPE1^XPDIA1;HLAPF2^XPDIA1;;HLAPDEL^XPDIA1(%)
+"RTN","XPDE",122,0)
+ ;;101;15;;;PRO^XPDTA;PROF1^XPDIA;PROE1^XPDIA;PROF2^XPDIA;;PRODEL^XPDIA
+"RTN","XPDE",123,0)
+ ;;8994;16;1;;;;RPCE1^XPDIA1;;;RPCDEL^XPDIA1
+"RTN","XPDE",124,0)
+ ;;409.61;17;1;;;;LME1^XPDIA1;;;LMDEL^XPDIA1
+"RTN","XPDE",125,0)
+ ;;19;18;;;OPT^XPDTA;OPTF1^XPDIA;OPTE1^XPDIA;OPTF2^XPDIA;;OPTDEL^XPDIA
+"RTN","XPDE",126,0)
+ ;;8994.2;19;1;;;;CRC32PE^XPDIA1;;;CRC32DEL^XPDIA1
+"RTN","XPDE",127,0)
+ ;;8989.51;20;;;PAR1E1^XPDTA2;PAR1F1^XPDIA3;PAR1E1^XPDIA3;PAR1F2^XPDIA3;;PAR1DEL^XPDIA3(%)
+"RTN","XPDE",128,0)
+ ;;8989.52;21;1;;PAR2E1^XPDTA2;PAR2F1^XPDIA3;PAR2E1^XPDIA3;PAR2F2^XPDIA3;;PAR2DEL^XPDIA3(%)
+"RTN","XPDE",129,0)
+ ;;779.2;22;1;;HLOAP^XPDTA1;;HLOE^XPDIA1;;;
+"RTN","XPDE",130,0)
+ ;;8993;23;1;;XULM^XPDTA2;;XULM^XPDIA3;;;
+"RTN","XPDE",131,0)
+ ;;9002226;24;1;;BLD^XPDIHS;BLD1^XPDIHS;BLD^XPDIHS;BLD1^XPDIHS;;BLD^XPDIHS
+"RTN","XPDE",132,0)
+ ;;1.62;25;;;;;POLFE1^XPDIA0;;;POLFDEL^XPDIA0(%)
+"RTN","XPDE",133,0)
+ ;;1.6;26;;;POL^XPDTA2;POLF1^XPDIA0;POLE1^XPDIA0;POLF2^XPDIA0;POLE2^XPDIA0;POLDEL^XPDIA0(%)
+"RTN","XPDE",134,0)
+ ;;1.61;27;1;;POLE^XPDTA2;;POLEE1^XPDIA0;;;POLEDEL^XPDIA0(%)
+"RTN","XPDE",135,0)
+ ;;1.5;28;;;ENT^XPDTA2;ENTF1^XPDIA0;ENTE1^XPDIA0;ENTF2^XPDIA0;;ENTDEL^XPDIA0(%)
+"RTN","XPDET")
+0^10^B36528246^B32656156
+"RTN","XPDET",1,0)
+XPDET ;SFISC/RSD - Input transforms & help for file 9.6 & 9.7 ;10/19/2002
+"RTN","XPDET",2,0)
+ ;;8.0;KERNEL;**15,39,41,44,51,58,66,137,229,393,539,672**;Jul 10, 1995;Build 28
+"RTN","XPDET",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XPDET",4,0)
+ Q
+"RTN","XPDET",5,0)
+INPUTB(X) ;input transform for NAME in BUILD file
+"RTN","XPDET",6,0)
+ ;X=user input
+"RTN","XPDET",7,0)
+ ;name must be unique
+"RTN","XPDET",8,0)
+ I $L(X)>50!($L(X)<3)!$D(^XPD(9.6,"B",X)) K X Q
+"RTN","XPDET",9,0)
+ I X["*" K:$P(X,"*",2,3)'?1.2N1"."1.2N.1(1"V",1"T").2N1"*"1.6N X Q
+"RTN","XPDET",10,0)
+ S %=$L(X," ") I %<2 K X Q
+"RTN","XPDET",11,0)
+ S %=$P(X," ",%) K:%'?1.2N1"."1.2N.1(1"V",1"T",1"B").2N X
+"RTN","XPDET",12,0)
+ Q
+"RTN","XPDET",13,0)
+INPUTE(X) ;input transform for ENTRIES in KERNEL FILES multiple
+"RTN","XPDET",14,0)
+ ;X=user input
+"RTN","XPDET",15,0)
+ N D,DD,DIC,DICR,DIX,DIY,DS,DO,XPDLK,Y
+"RTN","XPDET",16,0)
+ S XPDLK=$$GR(D1)
+"RTN","XPDET",17,0)
+ I XPDLK=""!X["*" K X Q
+"RTN","XPDET",18,0)
+ S DIC(0)="QEMZ",DIC=XPDLK
+"RTN","XPDET",19,0)
+ S:D1=9.8 DIC("S")="I $T(^@$P(^(0),U))]"""""
+"RTN","XPDET",20,0)
+ D ^DIC K:Y<0 X Q:'$D(X)
+"RTN","XPDET",21,0)
+ S X=Y(0,0)
+"RTN","XPDET",22,0)
+ ;check that this doesn't exist already
+"RTN","XPDET",23,0)
+ I $D(^XPD(9.6,D0,"KRN",D1,"NM","B",X)) K X Q
+"RTN","XPDET",24,0)
+ ;if fm file, change X to contain file # of template
+"RTN","XPDET",25,0)
+ I D1<.404 S X=$$TX(X,$P(Y(0),U,$S(D1=.403:8,1:4)))
+"RTN","XPDET",26,0)
+ ;POLICY FUNCTION file #1.62, entries below 1000 belong to FileMan
+"RTN","XPDET",27,0)
+ I D1=1.62 K:Y<1000 X
+"RTN","XPDET",28,0)
+ Q
+"RTN","XPDET",29,0)
+GLOBALE(X) ;input transform for GLOBAL multiple .01 field in file 9.6
+"RTN","XPDET",30,0)
+ I $L(X)>30!($L(X)<2) K X Q
+"RTN","XPDET",31,0)
+ I X["(",X'[")" K X Q
+"RTN","XPDET",32,0)
+ ;change ' back to " for subscripts, they were changed in the Pre-Lookup node of the DD, 7.5. This was done to trick FM, which doesn't allow " in .01 fields
+"RTN","XPDET",33,0)
+ S X=$TR(X,"'","""")
+"RTN","XPDET",34,0)
+ I '$D(@("^"_X)) K X
+"RTN","XPDET",35,0)
+ Q
+"RTN","XPDET",36,0)
+INPUTMB(X) ;input transform for field 10 and 11 in file 9.6
+"RTN","XPDET",37,0)
+ ;X=user input
+"RTN","XPDET",38,0)
+ N D,DD,DIC,DICR,DIX,DIY,DS,DO,Y
+"RTN","XPDET",39,0)
+ ;can't select a global or multi package or itself (D0)
+"RTN","XPDET",40,0)
+ S DIC(0)="QEMZ",DIC="^XPD(9.6,",DIC("S")="I '$P(^(0),U,3),Y'="_D0
+"RTN","XPDET",41,0)
+ D ^DIC K:Y<0 X Q:'$D(X)
+"RTN","XPDET",42,0)
+ S X=Y(0,0)
+"RTN","XPDET",43,0)
+ Q
+"RTN","XPDET",44,0)
+LOOKE(X) ;special lookup for ENTRIES in KERNEL FILES multiple
+"RTN","XPDET",45,0)
+ Q:X'?1.E1"*"
+"RTN","XPDET",46,0)
+ N %,XPD,XPDI,XPDIC,XPDF,XPDLK,XPDX,Y
+"RTN","XPDET",47,0)
+ S XPDLK=$$GR(D1),XPDIC=DIC,XPDF=D1
+"RTN","XPDET",48,0)
+ I XPDLK="" K X Q
+"RTN","XPDET",49,0)
+ G:$E(X)="-" DEL
+"RTN","XPDET",50,0)
+ S XPDX=$P(X,"*"),XPDI("IEN")=0
+"RTN","XPDET",51,0)
+ D LIST^DIC(D1,"","@;.01","","*",.XPDI,XPDX,"","I $$SCR^XPDET(Y)")
+"RTN","XPDET",52,0)
+ I '$G(^TMP("DILIST",$J,0)) K X Q
+"RTN","XPDET",53,0)
+ K ^TMP("XPDX",$J)
+"RTN","XPDET",54,0)
+ ;loop thru list from lister and file using UPDATE^DIE
+"RTN","XPDET",55,0)
+ F XPDI=1:1 S X=$G(^TMP("DILIST",$J,"ID",XPDI,.01)) Q:X=""  D
+"RTN","XPDET",56,0)
+ .;FM template will have file # associated with the template name
+"RTN","XPDET",57,0)
+ .S:D1<.404 %=^TMP("DILIST",$J,2,XPDI)_",",X=$$TX(X,$$GET1^DIQ(D1,%,$$TF(D1),"I"))
+"RTN","XPDET",58,0)
+ .;Lock Template, #8993, need to remove leading "^" if there
+"RTN","XPDET",59,0)
+ .S:D1=8993&($E(X)="^") X=$P(X,"^",2)
+"RTN","XPDET",60,0)
+ .S Y="+"_XPDI_","_D1_","_D0_",",^TMP("XPDX",$J,9.68,Y,.01)=X,^(.03)=0
+"RTN","XPDET",61,0)
+ I $D(^TMP("XPDX",$J)) D UPDATE^DIE("","^TMP(""XPDX"",$J)","^TMP(""XPD"",$J)")
+"RTN","XPDET",62,0)
+ ;if in Screenman then call MLOAD to update screen
+"RTN","XPDET",63,0)
+ I $D(DDS),$D(^TMP("XPD",$J)) D MLOAD^DDSUTL("^TMP(""XPD"",$J)")
+"RTN","XPDET",64,0)
+ S X=""
+"RTN","XPDET",65,0)
+ K ^TMP("XPDX",$J),^TMP("XPD",$J)
+"RTN","XPDET",66,0)
+ Q
+"RTN","XPDET",67,0)
+DEL ;delete using wild card
+"RTN","XPDET",68,0)
+ I X'?1"-"1.E1"*" K X Q
+"RTN","XPDET",69,0)
+ S X=$E(X,2,$L(X)-1),XPDX=X S:$L(X) XPDI("IEN")=0
+"RTN","XPDET",70,0)
+ D LIST^DIC(9.68,","_D1_","_D0_",","","","*",.XPDI,XPDX)
+"RTN","XPDET",71,0)
+ I '$G(^TMP("DILIST",$J,0)) K X Q
+"RTN","XPDET",72,0)
+ N DIK,DA,D2
+"RTN","XPDET",73,0)
+ S DIK=XPDIC,DA(1)=D1,DA(2)=D0
+"RTN","XPDET",74,0)
+ F XPDI=1:1 S (DA,D2)=$G(^TMP("DILIST",$J,2,XPDI)) Q:'DA  D
+"RTN","XPDET",75,0)
+ .D ^DIK
+"RTN","XPDET",76,0)
+ I $D(DDS) D MDEL^DDSUTL("^TMP(""DILIST"",$J,2)")
+"RTN","XPDET",77,0)
+ S X=""
+"RTN","XPDET",78,0)
+ K ^TMP("DILIST",$J)
+"RTN","XPDET",79,0)
+ Q
+"RTN","XPDET",80,0)
+HELP ;executable help of ENTRIES in KERNEL FILE multiple
+"RTN","XPDET",81,0)
+ N D,DIC,DIE,DIX,DIY,DO,DZ,DS,X,Y
+"RTN","XPDET",82,0)
+ ;file 9.8 is routine file, check that routine exists
+"RTN","XPDET",83,0)
+ S DIC=$$GR(D1),DIC(0)="M",X="??" Q:DIC=""  S:D1=9.8 DIC("S")="I $T(^@$P(^(0),U))]"""""
+"RTN","XPDET",84,0)
+ D ^DIC Q
+"RTN","XPDET",85,0)
+ ;
+"RTN","XPDET",86,0)
+HELPO ;executable help of INSTALL ORDER in KERNEL FILES multiple
+"RTN","XPDET",87,0)
+ N Y
+"RTN","XPDET",88,0)
+ W !,"Numbers in use:  ORDER     FILE#" S Y=0
+"RTN","XPDET",89,0)
+ F  S Y=$O(^XPD(9.6,D0,"KRN","AC",Y)) Q:'Y  W !,?18,$J(Y,2),?28,$O(^(Y,0))
+"RTN","XPDET",90,0)
+ W ! Q
+"RTN","XPDET",91,0)
+ ;
+"RTN","XPDET",92,0)
+HELPMB ;executable help of fields 10 & 11 in file 9.6
+"RTN","XPDET",93,0)
+ N D,DIC,DIE,DIX,DIY,DO,DZ,DS,X,Y
+"RTN","XPDET",94,0)
+ S DIC="^XPD(9.6,",DIC(0)="M",X="??",DIC("S")="I '$P(^(0),U,3),Y'="_D0
+"RTN","XPDET",95,0)
+ D ^DIC Q
+"RTN","XPDET",96,0)
+ ;
+"RTN","XPDET",97,0)
+SCRA(Y) ;screen of ACTION field in ENTRIES multiple in KERNEL FILES multiple, Y=action
+"RTN","XPDET",98,0)
+ ;Y=0 - send, 1 - delete, 2 - link, 3 - merge, 4 - attach, 5 - disable
+"RTN","XPDET",99,0)
+ ;all entries can send to site
+"RTN","XPDET",100,0)
+ ;D0=Build ien, D1=File #, D2=record #
+"RTN","XPDET",101,0)
+ Q:'Y 1
+"RTN","XPDET",102,0)
+ ;.5=function file, can't delete, all others can
+"RTN","XPDET",103,0)
+ I Y=1 Q (D1'=.5)
+"RTN","XPDET",104,0)
+ ;then rest of code check if it is a Option, Protocal, and Policy and can have MENU ITEMS
+"RTN","XPDET",105,0)
+ Q:D1'=19&(D1'=101)&(D1'=1.6) 0
+"RTN","XPDET",106,0)
+ ;only Options and Protocol can disable, Policy can't
+"RTN","XPDET",107,0)
+ I Y=5 Q (D1'=1.6)
+"RTN","XPDET",108,0)
+ N FGR,X,XPDF,XPDT,XPDY,XPDZ
+"RTN","XPDET",109,0)
+ ;get X=name, FGR=global reference, XPDF=file #
+"RTN","XPDET",110,0)
+ S XPDY=Y,XPDF=D1,X=$P(^XPD(9.6,D0,"KRN",D1,"NM",D2,0),U),FGR=$$FILE^XPDV(D1)
+"RTN","XPDET",111,0)
+ Q:X="" 0
+"RTN","XPDET",112,0)
+ ;X=ien of protocol, option, or policy
+"RTN","XPDET",113,0)
+ S X=+$O(@FGR@("B",X,0)) Q:'X 0
+"RTN","XPDET",114,0)
+ ;get type
+"RTN","XPDET",115,0)
+ S XPDT=$S(XPDF=1.6:$P($G(@FGR@(X,0)),U,2),1:$P($G(@FGR@(X,0)),U,4))
+"RTN","XPDET",116,0)
+ ;Policy; Type=Rule only send & delete
+"RTN","XPDET",117,0)
+ I XPDF=1.6,XPDT="R" Q (XPDY<2)
+"RTN","XPDET",118,0)
+ ;Policy; Type=Set or Policy, if Members then okay, else allow only send & delete
+"RTN","XPDET",119,0)
+ I XPDF=1.6,XPDT'="R" Q:$O(@FGR@(X,10,0)) 1 Q (XPDY<2)
+"RTN","XPDET",120,0)
+ ;all Options and Protocols, except Event Drivers, can be attached
+"RTN","XPDET",121,0)
+ I XPDY=4 Q '(XPDF=101&(XPDT="E"))
+"RTN","XPDET",122,0)
+ ;Protocol and Type is Subscriber can't do anything else
+"RTN","XPDET",123,0)
+ I XPDF=101,XPDT="S" Q 0
+"RTN","XPDET",124,0)
+ ;if it has SUBSCRIBERS, node 775 then ok
+"RTN","XPDET",125,0)
+ I $O(@FGR@(X,775,0)) Q 1
+"RTN","XPDET",126,0)
+ ;if type is menu,potocol,protocol menu,limited,extended,window suite
+"RTN","XPDET",127,0)
+ I "MOQLXZ"[XPDT Q 1
+"RTN","XPDET",128,0)
+ ;if it has ITEMs, node 10 then ok
+"RTN","XPDET",129,0)
+ I $O(@FGR@(X,10,0)) Q 1
+"RTN","XPDET",130,0)
+ Q 0
+"RTN","XPDET",131,0)
+ ;
+"RTN","XPDET",132,0)
+ ;only Fileman templates need to know what file they are associated with.
+"RTN","XPDET",133,0)
+ ;this value is also triggered to field .02 in the DD.
+"RTN","XPDET",134,0)
+TX(X,Y) ;X=template name, Y=file #
+"RTN","XPDET",135,0)
+ Q X_"    FILE #"_Y
+"RTN","XPDET",136,0)
+ ;
+"RTN","XPDET",137,0)
+TF(F) ;F=file, return field of file# for templates
+"RTN","XPDET",138,0)
+ Q $S(F>.403:"",F<.403:4,1:7)
+"RTN","XPDET",139,0)
+ ;
+"RTN","XPDET",140,0)
+GR(X) Q $G(^DIC(X,0,"GL"))
+"RTN","XPDET",141,0)
+ ;
+"RTN","XPDET",142,0)
+ ;screens checks that X is not already in the ENTRIES multiple
+"RTN","XPDET",143,0)
+SCR(Y) ;screen logic for ENTRIES multiple in file 9.6
+"RTN","XPDET",144,0)
+ N %,X,Z
+"RTN","XPDET",145,0)
+ S Z=^(0),X=$P(Z,U)
+"RTN","XPDET",146,0)
+ ;FM files are less than .44
+"RTN","XPDET",147,0)
+ I XPDF<.44 D  Q:X="" 0
+"RTN","XPDET",148,0)
+ .S %=$S(XPDF=.403:$P(Z,U,8),1:$P(Z,U,4)),X=X_"    FILE #"_%
+"RTN","XPDET",149,0)
+ .S:XPDF'=.403&($P(Z,U,8)>2) %=0 S:'% X=""
+"RTN","XPDET",150,0)
+ ;routine must exist and must be type 'R'
+"RTN","XPDET",151,0)
+ I XPDF=9.8 Q:$T(^@X)=""!($P(Z,U,2)'="R") 0
+"RTN","XPDET",152,0)
+ Q '$D(@(XPDIC_"""B"",X)"))
+"RTN","XPDET",153,0)
+ ;
+"RTN","XPDET",154,0)
+ ;screen checks that X is not in the exclude list, XPDN(0)
+"RTN","XPDET",155,0)
+SCR1(Y) ;screen logic for exclude list
+"RTN","XPDET",156,0)
+ N %,X
+"RTN","XPDET",157,0)
+ ;if name X is in the exclude list, XPDN(0,X), then fail
+"RTN","XPDET",158,0)
+ S Y(0)=^(0),X=$P(Y(0),U) Q:$D(XPDN(0,X)) 0
+"RTN","XPDET",159,0)
+ ;check if X is refered in the namespace by check the subscript
+"RTN","XPDET",160,0)
+ ;before X, if sub exist and $P(X,sub)="" then it is part of the
+"RTN","XPDET",161,0)
+ ;namespace, fail and return 0
+"RTN","XPDET",162,0)
+ S %=$O(XPDN(0,X),-1) I $L(%) Q:$P(X,%)="" 0
+"RTN","XPDET",163,0)
+ Q $$SCR(.Y)
+"RTN","XPDET",164,0)
+ ;
+"RTN","XPDET",165,0)
+ ;screen on PACKAGE LINK field in file 9.6,
+"RTN","XPDET",166,0)
+PCK(Y) ;check Package File name, Y=ien in package file
+"RTN","XPDET",167,0)
+ N %,Y,Z
+"RTN","XPDET",168,0)
+ S Z=^(0)
+"RTN","XPDET",169,0)
+ ;DA is undef when you are adding a new Build without a version number
+"RTN","XPDET",170,0)
+ Q:'$D(^XPD(9.6,+$G(DA),0)) 1
+"RTN","XPDET",171,0)
+ S Y=$L($P(Z,U)),%=$P(^XPD(9.6,DA,0),U),%=$$PKG^XPDUTL(%)
+"RTN","XPDET",172,0)
+ Q $P(Z,U)=$E(%,1,Y)!($P(Z,U,2)=%)
+"RTN","XPDET",173,0)
+VOLE(X) ;input transform for VOLUME SET multiple in INSTALL file
+"RTN","XPDET",174,0)
+ ;X=user input
+"RTN","XPDET",175,0)
+ N D,DD,DIC,DICR,DIX,DIY,DO,DS,XPD,Y,%
+"RTN","XPDET",176,0)
+ ;(0;11)=SIGNON/PRODUCTION
+"RTN","XPDET",177,0)
+ S DIC(0)="QEMZ",DIC="^%ZIS(14.5,",DIC("S")="I $P(^(0),U,11)"
+"RTN","XPDET",178,0)
+ D ^DIC K:Y<0 X Q:'$D(X)
+"RTN","XPDET",179,0)
+ S X=Y(0,0)
+"RTN","XPDET",180,0)
+ Q
+"RTN","XPDET",181,0)
+VOLH ;executable help for VOLUME SET multiple in INSTALL file
+"RTN","XPDET",182,0)
+ N D,DD,DIC,DIE,DIX,DIY,DO,DS,DZ,X,Y,%
+"RTN","XPDET",183,0)
+ S X="??",DIC(0)="QEMZ",DIC="^%ZIS(14.5,",DIC("S")="I $P(^(0),U,11)"
+"RTN","XPDET",184,0)
+ D ^DIC
+"RTN","XPDET",185,0)
+ Q
+"RTN","XPDET",186,0)
+ID97 ;identifier for Install file
+"RTN","XPDET",187,0)
+ N XPDET,XPD,XPD0,XPD1,XPD2,XPD9
+"RTN","XPDET",188,0)
+ S XPD0=$G(^(0)),XPD1=$G(^(1)),XPD2=$G(^(2)),XPD9=$P(XPD0,U,9),XPD="" Q:XPD9=""
+"RTN","XPDET",189,0)
+ D
+"RTN","XPDET",190,0)
+ .;Loaded, get DATE LOADED
+"RTN","XPDET",191,0)
+ .I 'XPD9 S XPD=$$FMTE^XLFDT($P(XPD0,U,3),2) Q
+"RTN","XPDET",192,0)
+ .Q:XPD9>4
+"RTN","XPDET",193,0)
+ .;Started, get INSTALL START TIME
+"RTN","XPDET",194,0)
+ .I XPD9=2 S XPD=$$FMTE^XLFDT($P(XPD1,U),2) Q
+"RTN","XPDET",195,0)
+ .;Completed or De-Installed, get INSTALL COMPLETE TIME
+"RTN","XPDET",196,0)
+ .I XPD9>2 S XPD=$$FMTE^XLFDT($P(XPD1,U,3),2) Q
+"RTN","XPDET",197,0)
+ .;Queued, get QUEUED TASK NUMBER
+"RTN","XPDET",198,0)
+ .I XPD9=1 S XPD="#"_$P(XPD0,U,6) Q
+"RTN","XPDET",199,0)
+ ;S XPDET(1)="   "_$$EXTERNAL^DILFD(9.7,.02,"",XPD9)_"  "_XPD,XPDET(1,"F")="?0"
+"RTN","XPDET",200,0)
+ S XPDET(1)="  "_XPD,XPDET(1,"F")="?0"
+"RTN","XPDET",201,0)
+ S:XPD2]"" XPDET(2)="=> "_$E(XPD2,1,70),XPDET(2,"F")="!?5"
+"RTN","XPDET",202,0)
+ D EN^DDIOL(.XPDET)
+"RTN","XPDET",203,0)
+ Q
+"RTN","XPDET",204,0)
+ ;not being used right now,
+"RTN","XPDET",205,0)
+DEL97(Y) ;delete access to file 9.7, 0-can't delete, 1-can
+"RTN","XPDET",206,0)
+ N %
+"RTN","XPDET",207,0)
+ S %=$P(^XPD(9.7,Y,0),U,9)
+"RTN","XPDET",208,0)
+ Q $S(%=3:1,%=2:0,$D(^XPD(9.7,"ASP",Y,1,Y)):1,1:0)
+"RTN","XPDET",209,0)
+ ;
+"RTN","XPDET",210,0)
+PAR964 ;Clear other fields if file is partial.  Called from within form
+"RTN","XPDET",211,0)
+ D PUT^DDSVAL(DIE,.DA,222.7,"n","","I") ;Send data NO
+"RTN","XPDET",212,0)
+ D PUT^DDSVAL(DIE,.DA,222.5,"","","I") ;Resolve pointer
+"RTN","XPDET",213,0)
+ D PUT^DDSVAL(DIE,.DA,222.8,"","","I") ;Sites Data
+"RTN","XPDET",214,0)
+ D PUT^DDSVAL(DIE,.DA,222.9,"n","","I") ;User Override
+"RTN","XPDET",215,0)
+ D PUT^DDSVAL(DIE,.DA,224,"","","I") ;Data Screen
+"RTN","XPDET",216,0)
+ Q
+"RTN","XPDET",217,0)
+ ;
+"RTN","XPDIA")
+0^16^B57775447^B54051187
+"RTN","XPDIA",1,0)
+XPDIA ;SFISC/RSD - Install Pre/Post Actions for Kernel Files ;09/13/2012
+"RTN","XPDIA",2,0)
+ ;;8.0;KERNEL;**10,15,21,28,44,58,68,131,145,672**;Jul 10, 1995;Build 28
+"RTN","XPDIA",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XPDIA",4,0)
+ Q
+"RTN","XPDIA",5,0)
+OPTF1 ;options file pre
+"RTN","XPDIA",6,0)
+ K ^TMP($J,"XPD")
+"RTN","XPDIA",7,0)
+ ;add Menu Text during a new record
+"RTN","XPDIA",8,0)
+ S XPDDR(1)="$P(OLDA(0),U,2)"
+"RTN","XPDIA",9,0)
+ Q
+"RTN","XPDIA",10,0)
+ ;
+"RTN","XPDIA",11,0)
+OPTE1 ;options entry pre
+"RTN","XPDIA",12,0)
+ N %,I
+"RTN","XPDIA",13,0)
+ ;XPDFL= 0-send,1-delete,2-link,3-merge,4-attach,5-disable
+"RTN","XPDIA",14,0)
+ ;attach & disable never get here
+"RTN","XPDIA",15,0)
+ S ^TMP($J,"XPD",DA)=XPDFL
+"RTN","XPDIA",16,0)
+ ;if Menu linking or merge save menu mult. and process in FPOS code
+"RTN","XPDIA",17,0)
+ I XPDFL>1 M ^TMP($J,"XPD",DA,10)=^XTMP("XPDI",XPDA,"KRN",19,OLDA,10) K ^XTMP("XPDI",XPDA,"KRN",19,OLDA,10)
+"RTN","XPDIA",18,0)
+ ;if Menu link, XPDQUIT prevents data merge
+"RTN","XPDIA",19,0)
+ I XPDFL=2 S XPDQUIT=1 Q
+"RTN","XPDIA",20,0)
+ ;if this is new to the site then disable and quit
+"RTN","XPDIA",21,0)
+ I $G(XPDNEW) D:XPDSET  Q
+"RTN","XPDIA",22,0)
+ .;quit if option already has out of order msg.
+"RTN","XPDIA",23,0)
+ .Q:$P(^XTMP("XPDI",XPDA,"KRN",19,OLDA,0),U,3)]""
+"RTN","XPDIA",24,0)
+ .S $P(^XTMP("XPDI",XPDA,"KRN",19,OLDA,0),U,3)=$P(XPDSET,U,3)
+"RTN","XPDIA",25,0)
+ .D ADD^XQOO1($P(XPDSET,U,2),19,DA)
+"RTN","XPDIA",26,0)
+ S I=^XTMP("XPDI",XPDA,"KRN",19,OLDA,0),%=^DIC(19,DA,0)
+"RTN","XPDIA",27,0)
+ ;$P(%,U,3)=out of order message, keep sending ooo msg
+"RTN","XPDIA",28,0)
+ S:$P(I,U,3)="" $P(I,U,3)=$P(%,U,3)
+"RTN","XPDIA",29,0)
+ ;if there is no new Security Key, save the old Key
+"RTN","XPDIA",30,0)
+ S:$P(I,U,6)="" $P(I,U,6)=$P(%,U,6)
+"RTN","XPDIA",31,0)
+ ;if there is no reverse key, save the old key and flag
+"RTN","XPDIA",32,0)
+ I $P($G(^XTMP("XPDI",XPDA,"KRN",19,OLDA,3)),U)="",$L($P($G(^DIC(19,DA,3)),U)) S $P(I,U,16)=$P(%,U,16),$P(^XTMP("XPDI",XPDA,"KRN",19,OLDA,3),U)=$P(^(3),U)
+"RTN","XPDIA",33,0)
+ S ^XTMP("XPDI",XPDA,"KRN",19,OLDA,0)=I
+"RTN","XPDIA",34,0)
+ ;if there is a new Description, kill the old Description
+"RTN","XPDIA",35,0)
+ K:$O(^XTMP("XPDI",XPDA,"KRN",19,OLDA,1,0)) ^DIC(19,DA,1)
+"RTN","XPDIA",36,0)
+ ;kill old RCPs (RPC)
+"RTN","XPDIA",37,0)
+ K ^DIC(19,DA,"RPC")
+"RTN","XPDIA",38,0)
+ ;kill old DIC variables: fields 30 thru 36 ;p672
+"RTN","XPDIA",39,0)
+ F I=30:1:36 K ^DIC(19,DA,I)
+"RTN","XPDIA",40,0)
+ ;if Menu Text, (U;1) is different, kill C x-ref
+"RTN","XPDIA",41,0)
+ S I=$G(^DIC(19,DA,"U")) I I]"",I'=$G(^XTMP("XPDI",XPDA,"KRN",19,OLDA,"U")) K ^DIC(19,"C",I)
+"RTN","XPDIA",42,0)
+ S I=0
+"RTN","XPDIA",43,0)
+ ;XPDFL=3-merge menu items, Quit
+"RTN","XPDIA",44,0)
+ ;the new menu items have already been saved into ^TMP, will restore in
+"RTN","XPDIA",45,0)
+ ;the file post action as a relink
+"RTN","XPDIA",46,0)
+ Q:XPDFL=3
+"RTN","XPDIA",47,0)
+ ;we are replacing menu items, kill the old.
+"RTN","XPDIA",48,0)
+ ;loop thru and kill "AD" x-ref., it will be reset with new options
+"RTN","XPDIA",49,0)
+ F  S I=$O(^DIC(19,DA,10,I)) Q:'I  S %=+$G(^(I,0)) K:% ^DIC(19,"AD",%,DA,I)
+"RTN","XPDIA",50,0)
+ ;kill Menus (10)
+"RTN","XPDIA",51,0)
+ K ^DIC(19,DA,10)
+"RTN","XPDIA",52,0)
+ Q
+"RTN","XPDIA",53,0)
+ ;
+"RTN","XPDIA",54,0)
+OPTF2 ;options file post
+"RTN","XPDIA",55,0)
+ N ACT,DA,DIK,I,X,Y,Y0
+"RTN","XPDIA",56,0)
+ ;loop thru all the new incomming options
+"RTN","XPDIA",57,0)
+ S DA=0,DIK=DIC F  S DA=$O(^TMP($J,"XPD",DA)) Q:'DA  S ACT=^(DA) D
+"RTN","XPDIA",58,0)
+ .;if use as link then goto OPTFL, just update menus
+"RTN","XPDIA",59,0)
+ .G:ACT=2 OPTFL
+"RTN","XPDIA",60,0)
+ .;repoint Bulletin (220;1) and Mail Group (220;3)
+"RTN","XPDIA",61,0)
+ .S Y0=$G(^DIC(19,DA,220)) I Y0]"" S $P(Y0,U)=$$LK("^XMB(3.6)",$P(Y0,U)),$P(Y0,U,3)=$$LK("^XMB(3.8)",$P(Y0,U,3)),^DIC(19,DA,220)=Y0
+"RTN","XPDIA",62,0)
+ .;repoint RPC (RPC;1)
+"RTN","XPDIA",63,0)
+ .S (I,X)=0 F  S I=$O(^DIC(19,DA,"RPC",I)) Q:'I  S Y0=$P($G(^(I,0)),U) D
+"RTN","XPDIA",64,0)
+ ..S Y=$$LK("^XWB(8994)",Y0)
+"RTN","XPDIA",65,0)
+ ..I 'Y K ^DIC(19,DA,"RPC",I) D BMES^XPDUTL(" RPC "_Y0_" in Option "_$P(^DIC(19,DA,0),U)_" **NOT FOUND**") Q
+"RTN","XPDIA",66,0)
+ ..S $P(^DIC(19,DA,"RPC",I,0),U)=Y,X=I_U_(X+1)
+"RTN","XPDIA",67,0)
+ .S:X $P(^DIC(19,DA,"RPC",0),U,3,4)=X
+"RTN","XPDIA",68,0)
+ .;repoint Package (0;12) and Help Frame (0;7)
+"RTN","XPDIA",69,0)
+ .S Y0=^DIC(19,DA,0),$P(Y0,U,12)=$$LK("^DIC(9.4)",$P(Y0,U,12)),$P(Y0,U,7)=$$LK("^DIC(9.2)",$P(Y0,U,7)),^DIC(19,DA,0)=Y0
+"RTN","XPDIA",70,0)
+OPTFL .;need to loop through ^TMP($J,"XPD",DA,10,I) these are menus that need to be
+"RTN","XPDIA",71,0)
+ .;merged, they could also be linked menu, but treat like merge
+"RTN","XPDIA",72,0)
+ .S I=0 F  S I=$O(^TMP($J,"XPD",DA,10,I)) Q:'I  S Y0=$G(^(I,0)),X=$G(^(U)) D:X]"" MENU(DA,X,Y0)
+"RTN","XPDIA",73,0)
+ .;loop thru Menu and repoint Option (0;1), text is on ^(U) node
+"RTN","XPDIA",74,0)
+ .;also need to recount all menus and reset zeroth node, use X
+"RTN","XPDIA",75,0)
+ .S (I,X)=0 F  S I=$O(^DIC(19,DA,10,I)) Q:'I  S Y0=$G(^(I,U)) D
+"RTN","XPDIA",76,0)
+ ..I $L(Y0) D  Q:'Y
+"RTN","XPDIA",77,0)
+ ...S Y=$$LK("^DIC(19)",Y0)
+"RTN","XPDIA",78,0)
+ ...K ^DIC(19,DA,10,I,U)
+"RTN","XPDIA",79,0)
+ ...I 'Y K ^DIC(19,DA,10,I) D BMES^XPDUTL(" Option "_Y0_" in Menu "_$P(^DIC(19,DA,0),U)_" **NOT FOUND**") Q
+"RTN","XPDIA",80,0)
+ ...S $P(^DIC(19,DA,10,I,0),U)=Y
+"RTN","XPDIA",81,0)
+ ..S X=I_U_(X+1)
+"RTN","XPDIA",82,0)
+ .S:X $P(^DIC(19,DA,10,0),U,3,4)=X
+"RTN","XPDIA",83,0)
+ .;re-index this option
+"RTN","XPDIA",84,0)
+ .D IX1^DIK
+"RTN","XPDIA",85,0)
+ K ^TMP($J,"XPD")
+"RTN","XPDIA",86,0)
+ Q
+"RTN","XPDIA",87,0)
+ ;
+"RTN","XPDIA",88,0)
+OPTDEL ;option delete
+"RTN","XPDIA",89,0)
+ D DEL("^DIC(19,",DUZ)
+"RTN","XPDIA",90,0)
+ D OPT^XPDIA2
+"RTN","XPDIA",91,0)
+ Q
+"RTN","XPDIA",92,0)
+ ;
+"RTN","XPDIA",93,0)
+PROF1 ;protocols file pre
+"RTN","XPDIA",94,0)
+ K ^TMP($J,"XPD")
+"RTN","XPDIA",95,0)
+ Q
+"RTN","XPDIA",96,0)
+ ;
+"RTN","XPDIA",97,0)
+PROE1 ;protocols entry pre
+"RTN","XPDIA",98,0)
+ G PROE1^XPDIA0
+"RTN","XPDIA",99,0)
+ ;
+"RTN","XPDIA",100,0)
+PROF2 ;protocols file post
+"RTN","XPDIA",101,0)
+ N ACT,DA,DIK,I,X,Y,Y0
+"RTN","XPDIA",102,0)
+ ;loop thru all the new incomming protocols
+"RTN","XPDIA",103,0)
+ S DA=0,DIK=DIC F  S DA=$O(^TMP($J,"XPD",DA)) Q:'DA  S ACT=^(DA) D
+"RTN","XPDIA",104,0)
+ .;if use as link then goto PROFL, just update menus
+"RTN","XPDIA",105,0)
+ .G:ACT=2 PROFL
+"RTN","XPDIA",106,0)
+ .;repoint Package (0;12)
+"RTN","XPDIA",107,0)
+ .S Y0=^ORD(101,DA,0) S:$L($P(Y0,U,12)) $P(Y0,U,12)=$$LK("^DIC(9.4)",$P(Y0,U,12)),^ORD(101,DA,0)=Y0
+"RTN","XPDIA",108,0)
+ .;repoint File Link (5;1), its a variable pointer
+"RTN","XPDIA",109,0)
+ .S Y0=$P($G(^ORD(101,DA,5)),U),Y=$P(Y0,";",2),Y0=$P(Y0,";")
+"RTN","XPDIA",110,0)
+ .I Y0,$L(Y) S Y0=$O(@("^"_Y_"""B"","""_Y0_""",0)")),$P(^ORD(101,DA,5),U)=$S(Y0:Y0_";"_Y,1:"")
+"RTN","XPDIA",111,0)
+ .;repoint HL7 fields, node 770
+"RTN","XPDIA",112,0)
+ .S Y0=$G(^ORD(101,DA,770)) I $L(Y0) D  S ^ORD(101,DA,770)=Y0
+"RTN","XPDIA",113,0)
+ ..S $P(Y0,U)=$$LK("^HL(771)",$P(Y0,U)),$P(Y0,U,2)=$$LK("^HL(771)",$P(Y0,U,2))
+"RTN","XPDIA",114,0)
+ ..S $P(Y0,U,3)=$$LK("^HL(771.2)",$P(Y0,U,3)),$P(Y0,U,11)=$$LK("^HL(771.2)",$P(Y0,U,11))
+"RTN","XPDIA",115,0)
+ ..S $P(Y0,U,4)=$$LK("^HL(779.001)",$P(Y0,U,4)),$P(Y0,U,7)=$$LK("^HLCS(870)",$P(Y0,U,7))
+"RTN","XPDIA",116,0)
+ ..S $P(Y0,U,8)=$$LK("^HL(779.003)",$P(Y0,U,8)),$P(Y0,U,9)=$$LK("^HL(779.003)",$P(Y0,U,9))
+"RTN","XPDIA",117,0)
+ ..S $P(Y0,U,10)=$$LK("^HL(771.5)",$P(Y0,U,10))
+"RTN","XPDIA",118,0)
+ .;loop thru Access and resolve (3;1), kill if it doesn't resolve
+"RTN","XPDIA",119,0)
+ .S (I,X)=0 F  S I=$O(^ORD(101,DA,3,I)) Q:'I  S Y0=$P($G(^(I,0)),U) D
+"RTN","XPDIA",120,0)
+ ..;Y0=.01 of Access(Security Key)
+"RTN","XPDIA",121,0)
+ ..S Y=$$LK("^DIC(19.1)",Y0)
+"RTN","XPDIA",122,0)
+ ..I 'Y K ^ORD(101,DA,3,I) D BMES^XPDUTL(" Key "_Y0_" in Protocol "_$P(^ORD(101,DA,0),U)_" **NOT FOUND**") Q
+"RTN","XPDIA",123,0)
+ ..S $P(^ORD(101,DA,3,I,0),U)=Y,X=I_U_(X+1)
+"RTN","XPDIA",124,0)
+ .S:X $P(^ORD(101,DA,3,0),U,3,4)=X
+"RTN","XPDIA",125,0)
+PROFL .;need to loop through ^TMP($J,"XPD",DA,10,I) these are menus that need to be
+"RTN","XPDIA",126,0)
+ .;merged, they are also linked menu, but treat like merge
+"RTN","XPDIA",127,0)
+ .S I=0 F  S I=$O(^TMP($J,"XPD",DA,10,I)) Q:'I  S Y0=$G(^(I,0)),X=$G(^(U)) D:X]"" MENU(DA,X,Y0)
+"RTN","XPDIA",128,0)
+ .;loop thru Menu and repoint Option (0;1), text is on ^(U) node
+"RTN","XPDIA",129,0)
+ .;also need to recount all menus and reset zeroth node, use X
+"RTN","XPDIA",130,0)
+ .S (I,X)=0 F  S I=$O(^ORD(101,DA,10,I)) Q:'I  S Y0=$G(^(I,U)) D
+"RTN","XPDIA",131,0)
+ ..I $L(Y0) D  Q:'Y
+"RTN","XPDIA",132,0)
+ ...S Y=$$LK("^ORD(101)",Y0)
+"RTN","XPDIA",133,0)
+ ...K ^ORD(101,DA,10,I,U)
+"RTN","XPDIA",134,0)
+ ...I 'Y K ^ORD(101,DA,10,I) D BMES^XPDUTL(" Protocol "_Y0_" in Protocol Menu "_$P(^ORD(101,DA,0),U)_" **NOT FOUND**") Q
+"RTN","XPDIA",135,0)
+ ...S $P(^ORD(101,DA,10,I,0),U)=Y
+"RTN","XPDIA",136,0)
+ ..S X=I_U_(X+1)
+"RTN","XPDIA",137,0)
+ .S:X $P(^ORD(101,DA,10,0),U,3,4)=X
+"RTN","XPDIA",138,0)
+ .;need to loop through ^TMP($J,"XPD",DA,775,I) these are subscribers that need to be
+"RTN","XPDIA",139,0)
+ .;merged, they are also linked subscriber, but treat like merge
+"RTN","XPDIA",140,0)
+ .S I=0 F  S I=$O(^TMP($J,"XPD",DA,775,I)) Q:'I  S Y0=$G(^(I,0)),X=$G(^(U)) D:X]"" SUBS(DA,X)
+"RTN","XPDIA",141,0)
+ .;loop thru subscriber and repoint Option (0;1), text is on ^(U) node
+"RTN","XPDIA",142,0)
+ .;also need to recount all menus and reset zeroth node, use X
+"RTN","XPDIA",143,0)
+ .S (I,X)=0 F  S I=$O(^ORD(101,DA,775,I)) Q:'I  S Y0=$G(^(I,U)) D
+"RTN","XPDIA",144,0)
+ ..I $L(Y0) D  Q:'Y
+"RTN","XPDIA",145,0)
+ ...S Y=$$LK("^ORD(101)",Y0)
+"RTN","XPDIA",146,0)
+ ...K ^ORD(101,DA,775,I,U)
+"RTN","XPDIA",147,0)
+ ...I 'Y K ^ORD(101,DA,775,I) D BMES^XPDUTL(" Protocol "_Y0_" in Protocol Subscriber "_$P(^ORD(101,DA,0),U)_" **NOT FOUND**") Q
+"RTN","XPDIA",148,0)
+ ...S $P(^ORD(101,DA,775,I,0),U)=Y
+"RTN","XPDIA",149,0)
+ ..S X=I_U_(X+1)
+"RTN","XPDIA",150,0)
+ .S:X $P(^ORD(101,DA,775,0),U,3,4)=X
+"RTN","XPDIA",151,0)
+ .;re-index this option
+"RTN","XPDIA",152,0)
+ .D IX1^DIK
+"RTN","XPDIA",153,0)
+ K ^TMP($J,"XPD")
+"RTN","XPDIA",154,0)
+ Q
+"RTN","XPDIA",155,0)
+ ;
+"RTN","XPDIA",156,0)
+PRODEL ;option delete
+"RTN","XPDIA",157,0)
+ D DEL("^ORD(101,",DUZ)
+"RTN","XPDIA",158,0)
+ D PRO^XPDIA2
+"RTN","XPDIA",159,0)
+ Q
+"RTN","XPDIA",160,0)
+ ;
+"RTN","XPDIA",161,0)
+LK(GR,X) ;lookup, GR=global root, X=lookup value
+"RTN","XPDIA",162,0)
+ Q:$G(X)="" ""
+"RTN","XPDIA",163,0)
+ N I S I=$O(@GR@("B",X,0))
+"RTN","XPDIA",164,0)
+ I I,$D(@GR@(I,0))#2 Q I
+"RTN","XPDIA",165,0)
+ Q ""
+"RTN","XPDIA",166,0)
+ ;
+"RTN","XPDIA",167,0)
+ADD(XPDSDD,XPDSDA,X) ;add to multiple, XPDSDD=sub DD#, XPDSDA=DA, X=value
+"RTN","XPDIA",168,0)
+ Q:$G(X)=""
+"RTN","XPDIA",169,0)
+ N XPD
+"RTN","XPDIA",170,0)
+ S XPD(XPDSDD,"?+1,"_XPDSDA_",",.01)=X
+"RTN","XPDIA",171,0)
+ D UPDATE^DIE("E","XPD")
+"RTN","XPDIA",172,0)
+ Q
+"RTN","XPDIA",173,0)
+ ;this is used to add menu items to an option or protocol
+"RTN","XPDIA",174,0)
+MENU(DA,X,X0) ;DA=ien of option/protocol, X=Menu item, X0=0 node of menu item
+"RTN","XPDIA",175,0)
+ N DIC,DLAYGO,DIK,D0,D1,I,Y,Y0
+"RTN","XPDIA",176,0)
+ S DIC=$S(XPDFIL=19:"^DIC(19,",1:"^ORD(101,")_DA_",10,",DIC(0)="L",DLAYGO=XPDFIL,(D0,DA(1))=DA
+"RTN","XPDIA",177,0)
+ S:'$D(@(DIC_"0)")) @(DIC_"0)")=U_$P(^DD(XPDFIL,10,0),U,2)
+"RTN","XPDIA",178,0)
+ S:$L($G(X0)) DIC("DR")="2///"_$P(X0,U,2)_";3///"_$P(X0,U,3)_$S($L($P(X0,U,4)):";4///"_$P(X0,U,4)_";5///"_$P(X0,U,5)_";6///"_$P(X0,U,6),1:"")
+"RTN","XPDIA",179,0)
+ D ^DIC
+"RTN","XPDIA",180,0)
+ Q
+"RTN","XPDIA",181,0)
+ ;this is used to add subscriber items to a protocol
+"RTN","XPDIA",182,0)
+SUBS(DA,X) ;DA=ien of protocol, X=subscriber
+"RTN","XPDIA",183,0)
+ N DIC,DLAYGO,DIK,D0,D1,I,Y,Y0
+"RTN","XPDIA",184,0)
+ S DIC="^ORD(101,"_DA_",775,",DIC(0)="L",DLAYGO=XPDFIL,(D0,DA(1))=DA
+"RTN","XPDIA",185,0)
+ S:'$D(@(DIC_"0)")) @(DIC_"0)")=U_$P(^DD(XPDFIL,775,0),U,2)
+"RTN","XPDIA",186,0)
+ D ^DIC
+"RTN","XPDIA",187,0)
+ Q
+"RTN","XPDIA",188,0)
+ ;
+"RTN","XPDIA",189,0)
+DEL(DIK,DUZ) ;delete
+"RTN","XPDIA",190,0)
+ N DA,XPDI,XPDF
+"RTN","XPDIA",191,0)
+ S XPDI=0,DUZ(0)="@",XPDF=+$P(DIK,"(",2)
+"RTN","XPDIA",192,0)
+ F  S XPDI=$O(^TMP($J,"XPDEL",XPDI)) Q:'XPDI  D
+"RTN","XPDIA",193,0)
+ .K ^TMP("DIFIXPT",$J) S DA=XPDI
+"RTN","XPDIA",194,0)
+ .D ^DIK ;FIXPT^DIA3("D",XPDF,XPDI)
+"RTN","XPDIA",195,0)
+ .I $D(^TMP("DIFIXPT",$J))  D WP^XPDUTL("^TMP(""DIFIXPT"",$J)")
+"RTN","XPDIA",196,0)
+ Q
+"RTN","XPDIA0")
+0^11^B34838028^B3762133
+"RTN","XPDIA0",1,0)
+XPDIA0 ;SFISC/RSD - Cont. of XPDIA ;03/09/2000  06:50
+"RTN","XPDIA0",2,0)
+ ;;8.0;KERNEL;**131,144,672**;Jul 10, 1995;Build 28
+"RTN","XPDIA0",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XPDIA0",4,0)
+ Q
+"RTN","XPDIA0",5,0)
+PROE1 ;protocols entry pre
+"RTN","XPDIA0",6,0)
+ N %,I
+"RTN","XPDIA0",7,0)
+ S ^TMP($J,"XPD",DA)=XPDFL
+"RTN","XPDIA0",8,0)
+ ;if Event Driver, subscriber multiple is on node 775
+"RTN","XPDIA0",9,0)
+ I $P(^XTMP("XPDI",XPDA,"KRN",101,OLDA,0),U,4)="E" D
+"RTN","XPDIA0",10,0)
+ . Q:$D(^XTMP("XPDI",XPDA,"KRN",101,OLDA,775))
+"RTN","XPDIA0",11,0)
+ . ;pre patch HL*1.6*57, convert menu multiple to subscriber
+"RTN","XPDIA0",12,0)
+ . M ^XTMP("XPDI",XPDA,"KRN",101,OLDA,775)=^XTMP("XPDI",XPDA,"KRN",101,OLDA,10)
+"RTN","XPDIA0",13,0)
+ . K ^XTMP("XPDI",XPDA,"KRN",101,OLDA,10)
+"RTN","XPDIA0",14,0)
+ ;if Menu linking or merge save menu and subscriber mult. and process in FPOS code
+"RTN","XPDIA0",15,0)
+ I XPDFL>1 D
+"RTN","XPDIA0",16,0)
+ . M ^TMP($J,"XPD",DA,775)=^XTMP("XPDI",XPDA,"KRN",101,OLDA,775),^TMP($J,"XPD",DA,10)=^XTMP("XPDI",XPDA,"KRN",101,OLDA,10)
+"RTN","XPDIA0",17,0)
+ . K ^XTMP("XPDI",XPDA,"KRN",101,OLDA,775),^(10)
+"RTN","XPDIA0",18,0)
+ ;if Menu link, XPDQUIT prevents data merge
+"RTN","XPDIA0",19,0)
+ I XPDFL=2 S XPDQUIT=1 Q
+"RTN","XPDIA0",20,0)
+ ;if this is new to the site then disable and quit
+"RTN","XPDIA0",21,0)
+ I $G(XPDNEW) D:XPDSET  Q
+"RTN","XPDIA0",22,0)
+ .;quit if option already has out of order msg.
+"RTN","XPDIA0",23,0)
+ .Q:$P(^XTMP("XPDI",XPDA,"KRN",101,OLDA,0),U,3)]""
+"RTN","XPDIA0",24,0)
+ .S $P(^XTMP("XPDI",XPDA,"KRN",101,OLDA,0),U,3)=$P(XPDSET,U,3)
+"RTN","XPDIA0",25,0)
+ .D ADD^XQOO1($P(XPDSET,U,2),101,DA)
+"RTN","XPDIA0",26,0)
+ S I=^XTMP("XPDI",XPDA,"KRN",101,OLDA,0),%=^ORD(101,DA,0)
+"RTN","XPDIA0",27,0)
+ ;$P(%,U,3)=disable message,
+"RTN","XPDIA0",28,0)
+ S:$P(I,U,3)]"" $P(I,U,3)=$P(%,U,3)
+"RTN","XPDIA0",29,0)
+ ;if there is no new Security Key, save the old Key
+"RTN","XPDIA0",30,0)
+ S:$P(I,U,6)="" $P(I,U,6)=$P(%,U,6)
+"RTN","XPDIA0",31,0)
+ S ^XTMP("XPDI",XPDA,"KRN",101,OLDA,0)=I
+"RTN","XPDIA0",32,0)
+ ;if there is a new Description, kill the old Description
+"RTN","XPDIA0",33,0)
+ K:$O(^XTMP("XPDI",XPDA,"KRN",101,OLDA,1,0)) ^ORD(101,DA,1)
+"RTN","XPDIA0",34,0)
+ ;kill old ACCESS multiple
+"RTN","XPDIA0",35,0)
+ K ^ORD(101,DA,3) S I=0
+"RTN","XPDIA0",36,0)
+ ;XPDFL=3-merge menu items, Quit
+"RTN","XPDIA0",37,0)
+ ;the new menu items have already been saved into ^TMP, will restore in
+"RTN","XPDIA0",38,0)
+ ;the file post action as a relink
+"RTN","XPDIA0",39,0)
+ Q:XPDFL=3
+"RTN","XPDIA0",40,0)
+ ;we are replacing menu items, kill the old.
+"RTN","XPDIA0",41,0)
+ ;loop thru and kill "AD" and "AB" x-ref., it will be reset with new options
+"RTN","XPDIA0",42,0)
+ F  S I=$O(^ORD(101,DA,10,I)) Q:'I  S %=+$G(^(I,0)) K:% ^ORD(101,"AD",%,DA,I)
+"RTN","XPDIA0",43,0)
+ F  S I=$O(^ORD(101,DA,775,I)) Q:'I  S %=+$G(^(I,0)) K:% ^ORD(101,"AB",%,DA,I)
+"RTN","XPDIA0",44,0)
+ K ^ORD(101,DA,10),^ORD(101,DA,775)
+"RTN","XPDIA0",45,0)
+ Q
+"RTN","XPDIA0",46,0)
+ ;
+"RTN","XPDIA0",47,0)
+ENTF1 ;ENTITY #1.5 file pre
+"RTN","XPDIA0",48,0)
+ K ^TMP($J,"XPD")
+"RTN","XPDIA0",49,0)
+ Q
+"RTN","XPDIA0",50,0)
+ ;
+"RTN","XPDIA0",51,0)
+ENTE1 ;ENTITY #1.5 entry pre
+"RTN","XPDIA0",52,0)
+ N %,%1,%2,%6
+"RTN","XPDIA0",53,0)
+ S ^TMP($J,"XPD",DA)=XPDFL
+"RTN","XPDIA0",54,0)
+ ;save ITEM multiple and process in file post ENTF2
+"RTN","XPDIA0",55,0)
+ M ^TMP($J,"XPD",DA,1)=^XTMP("XPDI",XPDA,"KRN",1.5,OLDA,1) K ^XTMP("XPDI",XPDA,"KRN",1.5,OLDA,1)
+"RTN","XPDIA0",56,0)
+ ;%1=DISPLAY NAME(#.1), %2=DEFAULT FILE NUMBER(#.02), %6=DATA MODEL(#.06)
+"RTN","XPDIA0",57,0)
+ S %=$G(^DDE(DA,0)),%1=$G(^DDE(DA,.1)),%2=$P(%,U,2),%6=$P(%,U,6)
+"RTN","XPDIA0",58,0)
+ ;kill the DEFAULT FILE NUMBER cross ref.
+"RTN","XPDIA0",59,0)
+ I %2 K ^DDE("F",%2,DA)
+"RTN","XPDIA0",60,0)
+ ;kill the DATA MODEL(%6) & DISPLAY NAME(%1) & DEFAULT FILE(%2) cross ref. ^DDE("FHIR" and ^DDE("SDA"
+"RTN","XPDIA0",61,0)
+ I %6]"",%1]"",%2 D
+"RTN","XPDIA0",62,0)
+ . I %6="F" K ^DDE("FHIR",$E(%1,1,30),%2,DA)
+"RTN","XPDIA0",63,0)
+ . I %6="S" K ^DDE("SDA",$E(%1,1,30),%2,DA)
+"RTN","XPDIA0",64,0)
+ ;just save the .01 field
+"RTN","XPDIA0",65,0)
+ S ^DDE(DA,0)=$P(%,U),%1=0
+"RTN","XPDIA0",66,0)
+ ;loop thru ITEM multiple #1, check ENTITY #.08
+"RTN","XPDIA0",67,0)
+ F  S %1=$O(^DDE(DA,1,%1)) Q:'%1  S %2=$G(^(%1,0)) D:$P(%2,U,8)]""
+"RTN","XPDIA0",68,0)
+ . ;kill the file level cross ref. ^DDE("AD",entity,ien,multiple)
+"RTN","XPDIA0",69,0)
+ . K ^DDE("AD",$P(%2,U,8),DA,%1)
+"RTN","XPDIA0",70,0)
+ ; kill rest of file
+"RTN","XPDIA0",71,0)
+ S %=0 F  S %=$O(^DDE(DA,%)) Q:%=""  K ^(%)
+"RTN","XPDIA0",72,0)
+ Q
+"RTN","XPDIA0",73,0)
+ ;
+"RTN","XPDIA0",74,0)
+ENTF2 ;ENTITY #1.5 file post
+"RTN","XPDIA0",75,0)
+ ;Loop ^TMP($J,"XPD",DA) and save ITEM multiple
+"RTN","XPDIA0",76,0)
+ N DA,DIK,%,%1,%8
+"RTN","XPDIA0",77,0)
+ S DIK="^DDE(",DA=0
+"RTN","XPDIA0",78,0)
+ F  S DA=$O(^TMP($J,"XPD",DA)) Q:'DA  S %1=0 D
+"RTN","XPDIA0",79,0)
+ . F  S %1=$O(^TMP($J,"XPD",DA,1,%1)) Q:'%1  S %8=$P($G(^(%1,0)),U,8) D:%8]""
+"RTN","XPDIA0",80,0)
+ .. ;resolve ENTITY(#.08) and put ien back
+"RTN","XPDIA0",81,0)
+ .. S %=$$LK^XPDIA("^DDE",%8) S:%]"" $P(^TMP($J,"XPD",DA,1,%1,0),U,8)=%
+"RTN","XPDIA0",82,0)
+ . ;save ITEM multiple into DDE
+"RTN","XPDIA0",83,0)
+ . M ^DDE(DA,1)=^TMP($J,"XPD",DA,1)
+"RTN","XPDIA0",84,0)
+ .;re-index this record
+"RTN","XPDIA0",85,0)
+ .D IX1^DIK
+"RTN","XPDIA0",86,0)
+ K ^TMP($J,"XPD")
+"RTN","XPDIA0",87,0)
+ Q
+"RTN","XPDIA0",88,0)
+ ;
+"RTN","XPDIA0",89,0)
+ENTDEL(RT) ;ENTITY #1.5 delete
+"RTN","XPDIA0",90,0)
+ D DELIEN^XPDUTL1(1.5,RT)
+"RTN","XPDIA0",91,0)
+ Q
+"RTN","XPDIA0",92,0)
+ ;
+"RTN","XPDIA0",93,0)
+POLF1 ;POLICY #1.6 file pre
+"RTN","XPDIA0",94,0)
+ K ^TMP($J,"XPD")
+"RTN","XPDIA0",95,0)
+ ;add TYPE during a new record, XPDDR is for identifiers
+"RTN","XPDIA0",96,0)
+ S XPDDR(.02)="$P(OLDA(0),U,2)"
+"RTN","XPDIA0",97,0)
+ Q
+"RTN","XPDIA0",98,0)
+ ;
+"RTN","XPDIA0",99,0)
+POLE1 ;POLICY entry pre
+"RTN","XPDIA0",100,0)
+ N %,I
+"RTN","XPDIA0",101,0)
+ ;XPDFL= 0-send,1-delete,2-link,3-merge,4-attach,5-disable
+"RTN","XPDIA0",102,0)
+ ;attach & disable never get here
+"RTN","XPDIA0",103,0)
+ S ^TMP($J,"XPD",DA)=XPDFL
+"RTN","XPDIA0",104,0)
+ ;if Member linking or merge save Member mult. and process in FPOS code
+"RTN","XPDIA0",105,0)
+ I XPDFL>1 M ^TMP($J,"XPD",DA,10)=^XTMP("XPDI",XPDA,"KRN",1.6,OLDA,10) K ^XTMP("XPDI",XPDA,"KRN",1.6,OLDA,10)
+"RTN","XPDIA0",106,0)
+ ;if Menu link, XPDQUIT prevents data merge
+"RTN","XPDIA0",107,0)
+ I XPDFL=2 S XPDQUIT=1 Q
+"RTN","XPDIA0",108,0)
+ ;if this is new to the site quit
+"RTN","XPDIA0",109,0)
+ I $G(XPDNEW) Q
+"RTN","XPDIA0",110,0)
+ ;if there is a new Description, kill the old Description
+"RTN","XPDIA0",111,0)
+ K:$O(^XTMP("XPDI",XPDA,"KRN",1.6,OLDA,1,0)) ^DIAC(1.6,DA,1)
+"RTN","XPDIA0",112,0)
+ Q
+"RTN","XPDIA0",113,0)
+ ;
+"RTN","XPDIA0",114,0)
+POLE2 ;POLICY #1.6 entry post
+"RTN","XPDIA0",115,0)
+ N %,%1,%2
+"RTN","XPDIA0",116,0)
+ ;repoint  ATTRIBUTE FUNCTION (0;4) and RESULT FUNCTION (0;7)
+"RTN","XPDIA0",117,0)
+ S %=^DIAC(1.6,DA,0) D  S ^DIAC(1.6,DA,0)=%
+"RTN","XPDIA0",118,0)
+ .F %1=4,7 S %2=$P(%,U,%1),$P(%,U,%1)=$$LK^XPDIA("^DIAC(1.62)",%2)
+"RTN","XPDIA0",119,0)
+ .Q
+"RTN","XPDIA0",120,0)
+ ;repoint DENY OBLIGATION (7) and PERMIT OBLIGATION (8)
+"RTN","XPDIA0",121,0)
+ F %1=7,8 S %=$G(^DIAC(1.6,DA,%1)) D:$L(%)
+"RTN","XPDIA0",122,0)
+ .S %2=$P(%,U),$P(%,U)=$$LK^XPDIA("^DIAC(1.62)",%2)
+"RTN","XPDIA0",123,0)
+ .S ^DIAC(1.6,DA,%1)=%
+"RTN","XPDIA0",124,0)
+ .Q
+"RTN","XPDIA0",125,0)
+ ;loop thru CONDITIONS (3) and repoint FUNCTION (0;2)
+"RTN","XPDIA0",126,0)
+ S %1=0 F  S %1=$O(^DIAC(1.6,DA,3,%1)) Q:'%1  S %=$G(^(%1,0)) D
+"RTN","XPDIA0",127,0)
+ .S %2=$P(%,U,2) Q:%2=""
+"RTN","XPDIA0",128,0)
+ .S $P(%,U,2)=$$LK^XPDIA("^DIAC(1.62)",%2)
+"RTN","XPDIA0",129,0)
+ .S ^DIAC(1.6,DA,3,%1,0)=%
+"RTN","XPDIA0",130,0)
+ .Q
+"RTN","XPDIA0",131,0)
+ Q
+"RTN","XPDIA0",132,0)
+ ;
+"RTN","XPDIA0",133,0)
+POLF2 ;POLICY #1.6 file post
+"RTN","XPDIA0",134,0)
+ N ACT,DA,DIK,I,X,Y,Y0
+"RTN","XPDIA0",135,0)
+ ;loop thru all the new incomming policies
+"RTN","XPDIA0",136,0)
+ S DA=0,DIK=DIC F  S DA=$O(^TMP($J,"XPD",DA)) Q:'DA  S ACT=^(DA) D
+"RTN","XPDIA0",137,0)
+ .;need to loop through ^TMP($J,"XPD",DA,10,I) these are MEMBERS that need to be
+"RTN","XPDIA0",138,0)
+ .;merged, they are also linked memeber, but treat like merge
+"RTN","XPDIA0",139,0)
+ .S I=0 F  S I=$O(^TMP($J,"XPD",DA,10,I)) Q:'I  S Y0=$G(^(I,0)),X=$G(^(U)) D:X]"" MEM(DA,X,Y0)
+"RTN","XPDIA0",140,0)
+ .;loop thru Menu and repoint Option (0;1), text is on ^(U) node
+"RTN","XPDIA0",141,0)
+ .;also need to recount all menus and reset zeroth node, use X
+"RTN","XPDIA0",142,0)
+ .S (I,X)=0 F  S I=$O(^DIAC(1.6,DA,10,I)) Q:'I  S Y0=$G(^(I,U)) D
+"RTN","XPDIA0",143,0)
+ ..I $L(Y0) D  Q:'Y
+"RTN","XPDIA0",144,0)
+ ...S Y=$$LK^XPDIA("^DIAC(1.6)",Y0)
+"RTN","XPDIA0",145,0)
+ ...K ^DIAC(1.6,DA,10,I,U)
+"RTN","XPDIA0",146,0)
+ ...I 'Y K ^DIAC(1.6,DA,10,I) D BMES^XPDUTL(" Policy "_Y0_" in Policy Members "_$P(^DIAC(1.6,DA,0),U)_" **NOT FOUND**") Q
+"RTN","XPDIA0",147,0)
+ ...S $P(^DIAC(1.6,DA,10,I,0),U)=Y
+"RTN","XPDIA0",148,0)
+ ...Q
+"RTN","XPDIA0",149,0)
+ ..S X=I_U_(X+1)
+"RTN","XPDIA0",150,0)
+ ..Q
+"RTN","XPDIA0",151,0)
+ .S:X $P(^DIAC(1.6,DA,10,0),U,3,4)=X
+"RTN","XPDIA0",152,0)
+ .;re-index this option
+"RTN","XPDIA0",153,0)
+ .D IX1^DIK
+"RTN","XPDIA0",154,0)
+ .Q
+"RTN","XPDIA0",155,0)
+ K ^TMP($J,"XPD")
+"RTN","XPDIA0",156,0)
+ Q
+"RTN","XPDIA0",157,0)
+ ;
+"RTN","XPDIA0",158,0)
+POLDEL(RT) ;POLICY delete
+"RTN","XPDIA0",159,0)
+ D DELPTR^XPDUTL1(1.6,RT) ;Delete any pointer entries
+"RTN","XPDIA0",160,0)
+ D DELIEN^XPDUTL1(1.6,RT) ;Delete the entries
+"RTN","XPDIA0",161,0)
+ Q
+"RTN","XPDIA0",162,0)
+ ;
+"RTN","XPDIA0",163,0)
+POLEE1 ;EVENT #1.61 entry pre
+"RTN","XPDIA0",164,0)
+ N %
+"RTN","XPDIA0",165,0)
+ S %=^XTMP("XPDI",XPDA,"KRN",1.61,OLDA,0)
+"RTN","XPDIA0",166,0)
+ ;repoint POLICY (0;5)
+"RTN","XPDIA0",167,0)
+ I $P(%,U,5)]"" S $P(%,U,5)=$$LK^XPDIA("^DIAC(1.6)",$P(%,U,5)),^XTMP("XPDI",XPDA,"KRN",1.61,OLDA,0)=%
+"RTN","XPDIA0",168,0)
+ Q
+"RTN","XPDIA0",169,0)
+ ;
+"RTN","XPDIA0",170,0)
+POLEDEL(RT) ;EVENT delete
+"RTN","XPDIA0",171,0)
+ D DELIEN^XPDUTL1(1.61,RT)
+"RTN","XPDIA0",172,0)
+ Q
+"RTN","XPDIA0",173,0)
+ ;
+"RTN","XPDIA0",174,0)
+POLFE1 ;FUNCTION #1.62 entry pre
+"RTN","XPDIA0",175,0)
+ ;if there is a new Description, kill the old Description
+"RTN","XPDIA0",176,0)
+ K:$O(^XTMP("XPDI",XPDA,"KRN",1.62,OLDA,2,0)) ^DIAC(1.62,DA,2)
+"RTN","XPDIA0",177,0)
+ Q
+"RTN","XPDIA0",178,0)
+ ;
+"RTN","XPDIA0",179,0)
+POLFDEL(RT) ;FUNCTION delete
+"RTN","XPDIA0",180,0)
+ D DELPTR^XPDUTL1(1.62,RT) ;Delete any pointer entries
+"RTN","XPDIA0",181,0)
+ D DELIEN^XPDUTL1(1.62,RT) ;Delete the entries
+"RTN","XPDIA0",182,0)
+ Q
+"RTN","XPDIA0",183,0)
+ ;
+"RTN","XPDIA0",184,0)
+ ;this is used to add member to a policy
+"RTN","XPDIA0",185,0)
+MEM(DA,X,X0) ;DA=ien of option/protocol, X=Member, X0=0 node of member
+"RTN","XPDIA0",186,0)
+ N DIC,DLAYGO,DIK,D0,D1,I,Y,Y0
+"RTN","XPDIA0",187,0)
+ S DIC="^DIAC(1.6,"_DA_",10,",DIC(0)="L",DLAYGO=XPDFIL,(D0,DA(1))=DA
+"RTN","XPDIA0",188,0)
+ S:'$D(@(DIC_"0)")) @(DIC_"0)")=U_$P(^DD(XPDFIL,10,0),U,2)
+"RTN","XPDIA0",189,0)
+ S:$L($G(X0)) DIC("DR")=".02///"_$P(X0,U,2)
+"RTN","XPDIA0",190,0)
+ D ^DIC
+"RTN","XPDIA0",191,0)
+ Q
+"RTN","XPDIA1")
+0^15^B73300100^B72722233
+"RTN","XPDIA1",1,0)
+XPDIA1 ;SFISC/RSD - Install Pre/Post Actions for Kernel files cont. ;06/24/2008
+"RTN","XPDIA1",2,0)
+ ;;8.0;KERNEL;**2,44,51,58,68,85,131,146,182,229,302,399,507,539,672**;Jul 10, 1995;Build 28
+"RTN","XPDIA1",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XPDIA1",4,0)
+ Q
+"RTN","XPDIA1",5,0)
+HLPF1 ;help frames file pre
+"RTN","XPDIA1",6,0)
+ K ^TMP($J,"XPD")
+"RTN","XPDIA1",7,0)
+ Q
+"RTN","XPDIA1",8,0)
+HLPE1 ;entry pre
+"RTN","XPDIA1",9,0)
+ S ^TMP($J,"XPD",DA)="" K ^DIC(9.2,DA,1),^(2),^(3),^(10)
+"RTN","XPDIA1",10,0)
+ Q
+"RTN","XPDIA1",11,0)
+HLPF2 ;file post
+"RTN","XPDIA1",12,0)
+ N DA,DIK,I,X,Y,Y0
+"RTN","XPDIA1",13,0)
+ ;need to send error message, need to setup message
+"RTN","XPDIA1",14,0)
+ S DA=0,DIK=DIC F  S DA=$O(^TMP($J,"XPD",DA)) Q:'DA  D
+"RTN","XPDIA1",15,0)
+ .;repoint Related Frame (2;0)
+"RTN","XPDIA1",16,0)
+ .S I=0 F  S I=$O(^DIC(9.2,DA,2,I)) Q:'I  S Y0=$G(^(I,0)),Y=$$LK^XPDIA("^DIC(9.2)",$P(Y0,U,2)),$P(^DIC(9.2,DA,2,I,0),U,2)=Y
+"RTN","XPDIA1",17,0)
+ .;repoint OBJECT (10;0)
+"RTN","XPDIA1",18,0)
+ .S (I,X)=0 F  S I=$O(^DIC(9.2,DA,10,I)) Q:'I  S Y0=$G(^(I,0)) D
+"RTN","XPDIA1",19,0)
+ ..S Y=$$LK^XPDIA("^MAG",$P(Y0,U)) S:Y $P(^DIC(9.2,DA,10,I,0),U)=Y,X=X+1_U_I
+"RTN","XPDIA1",20,0)
+ ..K:'Y ^DIC(9.2,DA,10,I)
+"RTN","XPDIA1",21,0)
+ .I X S $P(^DIC(9.2,DA,10,0),U,3,4)=$P(X,U,2)_U_+X
+"RTN","XPDIA1",22,0)
+ .D IX1^DIK
+"RTN","XPDIA1",23,0)
+ K ^TMP($J,"XPD")
+"RTN","XPDIA1",24,0)
+ Q
+"RTN","XPDIA1",25,0)
+HLPDEL ;help frame delete
+"RTN","XPDIA1",26,0)
+ N DA,DIK,XPDI,XPDJ
+"RTN","XPDIA1",27,0)
+ S XPDI=0
+"RTN","XPDIA1",28,0)
+ F  S XPDI=$O(^TMP($J,"XPDEL",XPDI)),XPDJ=0 Q:'XPDI  D
+"RTN","XPDIA1",29,0)
+ .S DIK="^DIC(9.2,XPDJ,2,"
+"RTN","XPDIA1",30,0)
+ .;check other frames that point to this one
+"RTN","XPDIA1",31,0)
+ .F  S XPDJ=$O(^DIC(9.2,"AE",XPDI,XPDJ)) Q:'XPDJ  S Z=$O(^(XPDJ,0)) D:Z
+"RTN","XPDIA1",32,0)
+ ..K DA S DA=Z,DA(1)=XPDJ D ^DIK
+"RTN","XPDIA1",33,0)
+ .;delete this frame
+"RTN","XPDIA1",34,0)
+ .K DA S DA=XPDI,DIK="^DIC(9.2," D ^DIK
+"RTN","XPDIA1",35,0)
+ Q
+"RTN","XPDIA1",36,0)
+BULE1 ;bulletin entry pre
+"RTN","XPDIA1",37,0)
+ N X,I S I=0
+"RTN","XPDIA1",38,0)
+ ;save current Mail Groups (2)
+"RTN","XPDIA1",39,0)
+ I $G(^XMB(3.6,DA,2,0))]"" S X(0)=^(0) F  S I=$O(^XMB(3.6,DA,2,I)) Q:'I  S X(I)=$G(^(I,0))
+"RTN","XPDIA1",40,0)
+ K ^XMB(3.6,DA)
+"RTN","XPDIA1",41,0)
+ ;after killing data, put back Mail Groups before data merge
+"RTN","XPDIA1",42,0)
+ I $D(X) S ^XMB(3.6,DA,2,0)=X(0),I=0 F  S I=$O(X(I)) Q:'I  S ^XMB(3.6,DA,2,I,0)=X(I)
+"RTN","XPDIA1",43,0)
+ Q
+"RTN","XPDIA1",44,0)
+BULDEL ;del bulletins
+"RTN","XPDIA1",45,0)
+ D DELIEN^XPDUTL1(3.6,$G(%))
+"RTN","XPDIA1",46,0)
+ Q
+"RTN","XPDIA1",47,0)
+MAILGF1 ;mail groups file pre
+"RTN","XPDIA1",48,0)
+ K ^TMP($J,"XPD")
+"RTN","XPDIA1",49,0)
+ Q
+"RTN","XPDIA1",50,0)
+MAILGE1 ;mail group entry pre
+"RTN","XPDIA1",51,0)
+ N I,J
+"RTN","XPDIA1",52,0)
+ S ^TMP($J,"XPD",DA)=""
+"RTN","XPDIA1",53,0)
+ ;save MEMBER GROUPS (5;0)
+"RTN","XPDIA1",54,0)
+ I $O(^XTMP("XPDI",XPDA,"KRN",3.8,OLDA,5,0)) M ^TMP($J,"XPD",DA,5)=^XTMP("XPDI",XPDA,"KRN",3.8,OLDA,5) K ^XTMP("XPDI",XPDA,"KRN",3.8,OLDA,5)
+"RTN","XPDIA1",55,0)
+ ;save MEMBER - REMOTE (6;0)
+"RTN","XPDIA1",56,0)
+ I $O(^XTMP("XPDI",XPDA,"KRN",3.8,OLDA,6,0)) M ^TMP($J,"XPD",DA,6)=^XTMP("XPDI",XPDA,"KRN",3.8,OLDA,6) K ^XTMP("XPDI",XPDA,"KRN",3.8,OLDA,6)
+"RTN","XPDIA1",57,0)
+ ;if there is a new Description, kill the old Description
+"RTN","XPDIA1",58,0)
+ K:$O(^XTMP("XPDI",XPDA,"KRN",3.8,OLDA,2,0)) ^XMB(3.8,DA,2)
+"RTN","XPDIA1",59,0)
+ ;I=current mail group, J=incoming mail group
+"RTN","XPDIA1",60,0)
+ S I=^XMB(3.8,DA,0),J=^XTMP("XPDI",XPDA,"KRN",3.8,OLDA,0)
+"RTN","XPDIA1",61,0)
+ ;save REFERENCE COUNT (0;4) & LAST REFERENCED (0;5)
+"RTN","XPDIA1",62,0)
+ S:$P(I,U,4) $P(J,U,4)=$P(I,U,4) S:$P(I,U,5) $P(J,U,5)=$P(I,U,5)
+"RTN","XPDIA1",63,0)
+ ;check COORDINATOR (0;7), bring in one that was asked during install question
+"RTN","XPDIA1",64,0)
+ D
+"RTN","XPDIA1",65,0)
+ .;get the existing coordinator, and set it
+"RTN","XPDIA1",66,0)
+ .I $P(I,U,7) S $P(J,U,7)=$P(I,U,7)
+"RTN","XPDIA1",67,0)
+ .;check if there is a pre-question
+"RTN","XPDIA1",68,0)
+ .S %=$O(^XPD(9.7,XPDA,"QUES","B","XPM"_OLDA_"#1",0)) Q:'%
+"RTN","XPDIA1",69,0)
+ .;if they entered a coordinator, then set it
+"RTN","XPDIA1",70,0)
+ .I $G(^XPD(9.7,XPDA,"QUES",%,1)) S $P(J,U,7)=^(1)
+"RTN","XPDIA1",71,0)
+ S ^XTMP("XPDI",XPDA,"KRN",3.8,OLDA,0)=J,I=$G(^XMB(3.8,DA,3))
+"RTN","XPDIA1",72,0)
+ ;save ORGANIZER (3;1)
+"RTN","XPDIA1",73,0)
+ I $P(I,U) S $P(^XTMP("XPDI",XPDA,"KRN",3.8,OLDA,3),U)=$P(I,U)
+"RTN","XPDIA1",74,0)
+ Q
+"RTN","XPDIA1",75,0)
+MAILGF2 ;mail group file post
+"RTN","XPDIA1",76,0)
+ N DA,DIK,XPDMDA,XPDI,Y
+"RTN","XPDIA1",77,0)
+ S XPDMDA=0,DIK="^XMB(3.8,"
+"RTN","XPDIA1",78,0)
+ F  S XPDMDA=$O(^TMP($J,"XPD",XPDMDA)) Q:'XPDMDA  D
+"RTN","XPDIA1",79,0)
+ .;merge & repoint MEMBER GROUP (5;0)
+"RTN","XPDIA1",80,0)
+ .S XPDI=0
+"RTN","XPDIA1",81,0)
+ .F  S XPDI=$O(^TMP($J,"XPD",XPDMDA,5,XPDI)) Q:'XPDI  S Y=$P($G(^(XPDI,0)),U) D:Y]"" ADD^XPDIA(3.811,XPDMDA,Y)
+"RTN","XPDIA1",82,0)
+ .;merge & repoint MEMBER - REMOTE (6;0)
+"RTN","XPDIA1",83,0)
+ .S XPDI=0
+"RTN","XPDIA1",84,0)
+ .F  S XPDI=$O(^TMP($J,"XPD",XPDMDA,6,XPDI)) Q:'XPDI  S Y=$P($G(^(XPDI,0)),U) D:Y]"" ADD^XPDIA(3.812,XPDMDA,Y)
+"RTN","XPDIA1",85,0)
+ .S DA=XPDMDA D IX1^DIK
+"RTN","XPDIA1",86,0)
+ K ^TMP($J,"XPD")
+"RTN","XPDIA1",87,0)
+ Q
+"RTN","XPDIA1",88,0)
+MAILGDEL(RT) ;Mail Group delete
+"RTN","XPDIA1",89,0)
+ D DELPTR^XPDUTL1(3.8,RT) ;Delete any pointer entries
+"RTN","XPDIA1",90,0)
+ D DELIEN^XPDUTL1(3.8,RT) ;Delete the entries
+"RTN","XPDIA1",91,0)
+ Q
+"RTN","XPDIA1",92,0)
+HLAPF1 ;HL7 application parameter #771 file pre
+"RTN","XPDIA1",93,0)
+ K ^TMP($J,"XPD")
+"RTN","XPDIA1",94,0)
+ Q
+"RTN","XPDIA1",95,0)
+HLAPE1 ;HL7 application parameter #771 entry pre
+"RTN","XPDIA1",96,0)
+ N I,J
+"RTN","XPDIA1",97,0)
+ S ^TMP($J,"XPD",DA)=""
+"RTN","XPDIA1",98,0)
+ S I=^HL(771,DA,0),J=^XTMP("XPDI",XPDA,"KRN",771,OLDA,0)
+"RTN","XPDIA1",99,0)
+ ;save FACILITY NAME (0;3)
+"RTN","XPDIA1",100,0)
+ S:$P(I,U,3)]"" $P(J,U,3)=$P(I,U,3)
+"RTN","XPDIA1",101,0)
+ ;repoint MAIL GROUP (0;4)
+"RTN","XPDIA1",102,0)
+ S:$P(J,U,4)]"" $P(J,U,4)=$$LK^XPDIA("^XMB(3.8)",$P(J,U,4))
+"RTN","XPDIA1",103,0)
+ ;repoint COUNTRY CODE (0;7)
+"RTN","XPDIA1",104,0)
+ S:$P(J,U,7)]"" $P(J,U,7)=$$LK^XPDIA("^HL(779.004)",$P(J,U,7))
+"RTN","XPDIA1",105,0)
+ S ^XTMP("XPDI",XPDA,"KRN",771,OLDA,0)=J
+"RTN","XPDIA1",106,0)
+ ;remove HL7 SEGMENT (SEG;0), HL7 MESSAGE (MSG;0)
+"RTN","XPDIA1",107,0)
+ K ^HL(771,DA,"SEG"),^("MSG")
+"RTN","XPDIA1",108,0)
+ Q
+"RTN","XPDIA1",109,0)
+HLAPF2 ;HL7 application parameter #771 file post
+"RTN","XPDIA1",110,0)
+ N DA,DIK,XPDI,X,Y
+"RTN","XPDIA1",111,0)
+ S DA=0,DIK="^HL(771,"
+"RTN","XPDIA1",112,0)
+ F  S DA=$O(^TMP($J,"XPD",DA)) Q:'DA  D
+"RTN","XPDIA1",113,0)
+ .;repoint HL7 SEGMENT (SEG;0)
+"RTN","XPDIA1",114,0)
+ .S XPDI=0
+"RTN","XPDIA1",115,0)
+ .F  S XPDI=$O(^HL(771,DA,"SEG",XPDI)) Q:'XPDI  S Y=$P($G(^(XPDI,0)),U) D
+"RTN","XPDIA1",116,0)
+ ..S X=$$LK^XPDIA("^HL(771.3)",$P(Y,U))
+"RTN","XPDIA1",117,0)
+ ..I X]"" S $P(^HL(771,DA,"SEG",XPDI,0),U)=X Q
+"RTN","XPDIA1",118,0)
+ ..K ^HL(771,DA,"SEG",XPDI)
+"RTN","XPDIA1",119,0)
+ .;repoint HL7 MESSAGE (MSG;0)
+"RTN","XPDIA1",120,0)
+ .S XPDI=0
+"RTN","XPDIA1",121,0)
+ .F  S XPDI=$O(^HL(771,DA,"MSG",XPDI)) Q:'XPDI  S Y=$P($G(^(XPDI,0)),U) D
+"RTN","XPDIA1",122,0)
+ ..S X=$$LK^XPDIA("^HL(771.3)",$P(Y,U))
+"RTN","XPDIA1",123,0)
+ ..I X]"" S $P(^HL(771,DA,"MSG",XPDI,0),U)=X Q
+"RTN","XPDIA1",124,0)
+ ..K ^HL(771,DA,"MSG",XPDI)
+"RTN","XPDIA1",125,0)
+ .D IX1^DIK
+"RTN","XPDIA1",126,0)
+ K ^TMP($J,"XPD")
+"RTN","XPDIA1",127,0)
+ Q
+"RTN","XPDIA1",128,0)
+HLLLPE ;HL7 lower level protocol #869.2 entry pre
+"RTN","XPDIA1",129,0)
+ N I,J,L,TMP,Y
+"RTN","XPDIA1",130,0)
+ S L=$P(^XTMP("XPDI",XPDA,"KRN",869.2,OLDA,0),U),I=0
+"RTN","XPDIA1",131,0)
+ ;loop thru logical links and find those pointing to this llp
+"RTN","XPDIA1",132,0)
+ F  S I=$O(^XTMP("XPDI",XPDA,"KRN",870,I)) Q:'I  S J=$G(^(I,0)) D
+"RTN","XPDIA1",133,0)
+ . Q:$P(J,U,3)'=L
+"RTN","XPDIA1",134,0)
+ . ;save llp into tmp, get the llp type field
+"RTN","XPDIA1",135,0)
+ . M TMP=^XTMP("XPDI",XPDA,"KRN",869.2,OLDA) S Y=$P(TMP(0),U,2)
+"RTN","XPDIA1",136,0)
+ . K TMP(-1),TMP(0)
+"RTN","XPDIA1",137,0)
+ . M ^XTMP("XPDI",XPDA,"KRN",870,I)=TMP S $P(^(I,0),U,3)=Y
+"RTN","XPDIA1",138,0)
+ S I=$P(^XTMP("XPDI",XPDA,"KRN",869.2,OLDA,0),U,2)
+"RTN","XPDIA1",139,0)
+ ;repoint LLP TYPE (0;2)
+"RTN","XPDIA1",140,0)
+ S:I]"" $P(^XTMP("XPDI",XPDA,"KRN",869.2,OLDA,0),U,2)=$$LK^XPDIA("^HLCS(869.1)",I)
+"RTN","XPDIA1",141,0)
+ S I=$P($G(^XTMP("XPDI",XPDA,"KRN",869.2,OLDA,100)),U)
+"RTN","XPDIA1",142,0)
+ ;repoint MAIL GROUP (100;1)
+"RTN","XPDIA1",143,0)
+ S:I]"" $P(^XTMP("XPDI",XPDA,"KRN",869.2,OLDA,100),U)=$$LK^XPDIA("^XMB(3.8)",I)
+"RTN","XPDIA1",144,0)
+ ;save HLLP DEVICE (200;1)
+"RTN","XPDIA1",145,0)
+ S I=$G(^HLCS(869.2,DA,200))
+"RTN","XPDIA1",146,0)
+ S:I $P(^XTMP("XPDI",XPDA,"KRN",869.2,OLDA,200),U)=$P(I,U)
+"RTN","XPDIA1",147,0)
+ ;save X3.28 DEVICE (300;1)
+"RTN","XPDIA1",148,0)
+ S I=$G(^HLCS(869.2,DA,300))
+"RTN","XPDIA1",149,0)
+ S:I $P(^XTMP("XPDI",XPDA,"KRN",869.2,OLDA,300),U)=$P(I,U)
+"RTN","XPDIA1",150,0)
+ ;save TCP/IP Start-up Node (400;6)
+"RTN","XPDIA1",151,0)
+ S I=$G(^HLCS(869.2,DA,400))
+"RTN","XPDIA1",152,0)
+ S:I $P(^XTMP("XPDI",XPDA,"KRN",869.2,OLDA,400),U,6)=$P(I,U,6)
+"RTN","XPDIA1",153,0)
+ Q
+"RTN","XPDIA1",154,0)
+HLLLE ;HL7 logical link #870 entry pre
+"RTN","XPDIA1",155,0)
+ N I,J,K,L,Y
+"RTN","XPDIA1",156,0)
+ S I=^HLCS(870,DA,0),J=^XTMP("XPDI",XPDA,"KRN",870,OLDA,0)
+"RTN","XPDIA1",157,0)
+ ;repoint INSTITUTION (0;2)
+"RTN","XPDIA1",158,0)
+ I $P(J,U,2)]"" S Y=$$LK^XPDIA("^DIC(4)",$P(J,U,2)) D:Y=""  S $P(J,U,2)=Y
+"RTN","XPDIA1",159,0)
+ .D BMES^XPDUTL(" Couldn't resolve Institution "_$P(J,U,2)_" for Logical Link "_$P(^HLCS(870,DA,0),U))
+"RTN","XPDIA1",160,0)
+ ;repoint LLP TYPE (0;3)
+"RTN","XPDIA1",161,0)
+ S:$P(J,U,3)]"" $P(J,U,3)=$$LK^XPDIA("^HLCS(869.1)",$P(J,U,3))
+"RTN","XPDIA1",162,0)
+ ;repoint MAILMAN DOMAIN (0;7)
+"RTN","XPDIA1",163,0)
+ I $P(J,U,7)]"" S Y=$$LK^XPDIA("^DIC(4.2)",$P(J,U,7)) D:Y=""  S $P(J,U,7)=Y
+"RTN","XPDIA1",164,0)
+ .D BMES^XPDUTL(" Couldn't resolve Domain "_$P(J,U,7)_" for Logical Link "_$P(^HLCS(870,DA,0),U))
+"RTN","XPDIA1",165,0)
+ ;save node 0; pieces 4,5,6,7,9,10,11,12,16,19,21
+"RTN","XPDIA1",166,0)
+ F L=4:1:7,9:1:12,16,19,21 S:$P(I,U,L)]"" $P(J,U,L)=$P(I,U,L)
+"RTN","XPDIA1",167,0)
+ ;set SHUTDOWN LLP (0;15) no for multi-listener and yes for all else
+"RTN","XPDIA1",168,0)
+ S Y=$P($G(^HLCS(870,DA,400)),U,3) S:Y]"" $P(J,U,15)=$S(Y="M":0,1:1)
+"RTN","XPDIA1",169,0)
+ S ^XTMP("XPDI",XPDA,"KRN",870,OLDA,0)=J
+"RTN","XPDIA1",170,0)
+ S I=$P($G(^XTMP("XPDI",XPDA,"KRN",870,OLDA,100)),U)
+"RTN","XPDIA1",171,0)
+ ;repoint MAIL GROUP (100;1)
+"RTN","XPDIA1",172,0)
+ S:I]"" $P(^XTMP("XPDI",XPDA,"KRN",870,OLDA,100),U)=$$LK^XPDIA("^XMB(3.8)",I)
+"RTN","XPDIA1",173,0)
+ ;save data from site on nodes 200,300,400,500
+"RTN","XPDIA1",174,0)
+ F L=200,300,400,500 S I=$G(^HLCS(870,DA,L)) D:I]""
+"RTN","XPDIA1",175,0)
+ . S J=$G(^XTMP("XPDI",XPDA,"KRN",870,OLDA,L)) Q:J=""
+"RTN","XPDIA1",176,0)
+ . ;check local data (I) and if exist set incomming data (J)
+"RTN","XPDIA1",177,0)
+ . F K=1:1:10 S Y=$P(I,U,K) S:Y]"" $P(J,U,K)=Y
+"RTN","XPDIA1",178,0)
+ . S ^XTMP("XPDI",XPDA,"KRN",870,OLDA,L)=J
+"RTN","XPDIA1",179,0)
+ ;remove following values when a Test site (not a Production site)
+"RTN","XPDIA1",180,0)
+ D:$P($$PARAM^HLCS2,U,3)'="P"
+"RTN","XPDIA1",181,0)
+ . ;MAILMAN DOMAIN (0;7), DNS DOMAIN (0;8)
+"RTN","XPDIA1",182,0)
+ . S $P(^XTMP("XPDI",XPDA,"KRN",870,OLDA,0),U,7,8)="^"
+"RTN","XPDIA1",183,0)
+ . ;TCP/IP ADDRESS (400,1), IPV6 ADDRESS (500,1)
+"RTN","XPDIA1",184,0)
+ . S J=$G(^XTMP("XPDI",XPDA,"KRN",870,OLDA,400))
+"RTN","XPDIA1",185,0)
+ . S:J]"" $P(^XTMP("XPDI",XPDA,"KRN",870,OLDA,400),U)=""
+"RTN","XPDIA1",186,0)
+ . S J=$G(^XTMP("XPDI",XPDA,"KRN",870,OLDA,500))
+"RTN","XPDIA1",187,0)
+ . S:J]"" $P(^XTMP("XPDI",XPDA,"KRN",870,OLDA,500),U)=""
+"RTN","XPDIA1",188,0)
+ Q
+"RTN","XPDIA1",189,0)
+KEYF1 ;SECURITY KEY file pre
+"RTN","XPDIA1",190,0)
+ K ^TMP($J,"XPD")
+"RTN","XPDIA1",191,0)
+ Q
+"RTN","XPDIA1",192,0)
+KEYE1 ;SECURITY KEY file entry pre
+"RTN","XPDIA1",193,0)
+ S ^TMP($J,"XPD",DA)=""
+"RTN","XPDIA1",194,0)
+ Q
+"RTN","XPDIA1",195,0)
+KEYF2 ;SECURITY KEY file post
+"RTN","XPDIA1",196,0)
+ N DA,DIK,I,X,Y,Y0
+"RTN","XPDIA1",197,0)
+ ;Repoint fields
+"RTN","XPDIA1",198,0)
+ S DA=0,DIK=DIC
+"RTN","XPDIA1",199,0)
+ F  S DA=$O(^TMP($J,"XPD",DA)) Q:'DA  D
+"RTN","XPDIA1",200,0)
+ . ;Repoint SUBORDINATE (3)
+"RTN","XPDIA1",201,0)
+ . S I=0 F  S I=$O(^DIC(19.1,DA,3,I)) Q:'I  S Y0=$G(^(I,0)) D
+"RTN","XPDIA1",202,0)
+ . . S Y=$$LK^XPDIA("^DIC(19.1)",$P(Y0,U)) S:Y $P(^DIC(19.1,DA,3,I,0),U)=Y
+"RTN","XPDIA1",203,0)
+ . ;MUTUALLY EXCLUSIVE KEYS (5)
+"RTN","XPDIA1",204,0)
+ . S (I,X)=0 F  S I=$O(^DIC(19.1,DA,5,I)) Q:'I  S Y0=$G(^(I,0)) D
+"RTN","XPDIA1",205,0)
+ . . S Y=$$LK^XPDIA("^DIC(19.1)",$P(Y0,U)) S:Y $P(^DIC(19.1,DA,5,I,0),U)=Y
+"RTN","XPDIA1",206,0)
+ . D IX1^DIK
+"RTN","XPDIA1",207,0)
+ K ^TMP($J,"XPD")
+"RTN","XPDIA1",208,0)
+ Q
+"RTN","XPDIA1",209,0)
+KEYDEL ;del security keys
+"RTN","XPDIA1",210,0)
+ N XPDI S XPDI=0
+"RTN","XPDIA1",211,0)
+ F  S XPDI=$O(^TMP($J,"XPDEL",XPDI)) Q:'XPDI  D DEL^XPDKEY(XPDI)
+"RTN","XPDIA1",212,0)
+ Q
+"RTN","XPDIA1",213,0)
+LME1 ;List Templates entry pre
+"RTN","XPDIA1",214,0)
+ ;kill old entry before data merge
+"RTN","XPDIA1",215,0)
+ K ^SD(409.61,DA)
+"RTN","XPDIA1",216,0)
+ Q
+"RTN","XPDIA1",217,0)
+LMDEL ;del list manager templates
+"RTN","XPDIA1",218,0)
+ D DELIEN^XPDUTL1(409.61,$NA(^TMP($J,"XPDEL")))
+"RTN","XPDIA1",219,0)
+ Q
+"RTN","XPDIA1",220,0)
+RPCDEL ;del Kernel RPC, file 8994
+"RTN","XPDIA1",221,0)
+ D DELIEN^XPDUTL1(8994,$G(%))
+"RTN","XPDIA1",222,0)
+ Q
+"RTN","XPDIA1",223,0)
+RPCE1 ;RPC pre entry, file 8994
+"RTN","XPDIA1",224,0)
+ ;kill Input parameters multiple, field #2
+"RTN","XPDIA1",225,0)
+ K ^XWB(8994,DA,2)
+"RTN","XPDIA1",226,0)
+ Q
+"RTN","XPDIA1",227,0)
+CRC32PE ;pre entry for Kernel RPCs CRC32
+"RTN","XPDIA1",228,0)
+ ;if there is a new Description, kill the old Description
+"RTN","XPDIA1",229,0)
+ K:$O(^XTMP("XPDI",XPDA,"KRN",8994.2,OLDA,1,0)) ^XWB(8994.2,DA,1)
+"RTN","XPDIA1",230,0)
+ Q
+"RTN","XPDIA1",231,0)
+CRC32DEL ;del Kernel RPCs CRC32
+"RTN","XPDIA1",232,0)
+ D DELIEN^XPDUTL1(8994.2,$G(%))
+"RTN","XPDIA1",233,0)
+ Q
+"RTN","XPDIA1",234,0)
+HLAPDEL(RT) ;del HL7 application parameter #771
+"RTN","XPDIA1",235,0)
+ D DELIEN^XPDUTL1(771,RT)
+"RTN","XPDIA1",236,0)
+ Q
+"RTN","XPDIA1",237,0)
+HLLLDEL(RT) ;del HL7 logical link #870
+"RTN","XPDIA1",238,0)
+ N DA,DIK,XPDI,XPDJ,Y
+"RTN","XPDIA1",239,0)
+ S XPDI=0
+"RTN","XPDIA1",240,0)
+ ;loop thru protocols, #101, get LL field, 770.7 (700;7)
+"RTN","XPDIA1",241,0)
+ F  S XPDI=$O(^ORD(101,XPDI)) Q:'XPDI  S Y=$P($G(^(XPDI,700)),U,7) D:Y
+"RTN","XPDIA1",242,0)
+ . Q:'$D(^TMP($J,"XPDEL",Y))
+"RTN","XPDIA1",243,0)
+ . K XPDJ S XPDJ(101,XPDI_",",770.7)="@"
+"RTN","XPDIA1",244,0)
+ . D FILE^DIE("","XPDJ")
+"RTN","XPDIA1",245,0)
+ ;subscription, #774
+"RTN","XPDIA1",246,0)
+ F  S XPDI=$O(TMP($J,"XPDEL",XPDI)) Q:'XPDI  D:$D(^HLS(774,"C",XPDI))
+"RTN","XPDIA1",247,0)
+ . S XPDJ=0 F  S XPDJ=$O(^HLS(774,"C",XPDI,XPDJ))
+"RTN","XPDIA1",248,0)
+ D DELIEN^XPDUTL1(870,RT)
+"RTN","XPDIA1",249,0)
+ Q
+"RTN","XPDIA1",250,0)
+HLOE ;HLO application registry #779.2
+"RTN","XPDIA1",251,0)
+ N I,J,K,L,Y
+"RTN","XPDIA1",252,0)
+ S I=^HLD(779.2,DA,0),J=^XTMP("XPDI",XPDA,"KRN",779.2,OLDA,0)
+"RTN","XPDIA1",253,0)
+ ;repoint APPLICATION SPECIFIC LISTENER (0;9)
+"RTN","XPDIA1",254,0)
+ I $P(J,U,9)]"" S Y=$$LK^XPDIA("^HLCS(870)",$P(J,U,9)) D:Y=""  S $P(J,U,9)=Y
+"RTN","XPDIA1",255,0)
+ .D BMES^XPDUTL(" Couldn't resolve APPLICATION SPECIFIC LISTENER "_$P(J,U,2)_" HLO APPLICATION "_$P(I,U))
+"RTN","XPDIA1",256,0)
+ S ^XTMP("XPDI",XPDA,"KRN",779.2,OLDA,0)=J
+"RTN","XPDIA1",257,0)
+ ;repoint Package File Link (2;1)
+"RTN","XPDIA1",258,0)
+ S J=$P($G(^XTMP("XPDI",XPDA,"KRN",779.2,OLDA,2)),U)
+"RTN","XPDIA1",259,0)
+ S:J]"" $P(^XTMP("XPDI",XPDA,"KRN",779.2,OLDA,2),U)=$$LK^XPDIA("^DIC(9.4)",J)
+"RTN","XPDIA1",260,0)
+ ;save data from site on nodes 200,300,400
+"RTN","XPDIA1",261,0)
+ Q
+"RTN","XPDIA3")
+0^3^B12998832^B10647739
+"RTN","XPDIA3",1,0)
+XPDIA3 ;SFISC/RWF - Install Pre/Post Actions for Kernel files cont. ;6/22/06  09:13
+"RTN","XPDIA3",2,0)
+ ;;8.0;KERNEL;**201,302,393,498,672**;Jul 10, 1995;Build 28
+"RTN","XPDIA3",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XPDIA3",4,0)
+ Q
+"RTN","XPDIA3",5,0)
+ ;^XTMP("XPDI",,XPDA,"KRN",XPDFILE,OLDA) is the global root
+"RTN","XPDIA3",6,0)
+ ;XPDNM=package name, XPDA=ien in ^XPD(9.6,
+"RTN","XPDIA3",7,0)
+ ;DA=ien in file, OLDA= ien in ^XTMP
+"RTN","XPDIA3",8,0)
+ ;
+"RTN","XPDIA3",9,0)
+PAR0F2 ;PARAMETER file 8989.5: post.  This is a fake entry called from the post of file 8989.51
+"RTN","XPDIA3",10,0)
+ ;Now load any entries from 8989.5
+"RTN","XPDIA3",11,0)
+ N XP1,XP2,XP3,DIK,OLDA,DA,ERR,PN,PE,PT,ROOT
+"RTN","XPDIA3",12,0)
+ S XP1=$O(^XTMP("XPDI",XPDA,"PKG",0)) ;Get the package
+"RTN","XPDIA3",13,0)
+ Q:'XP1  S PN=$G(^XTMP("XPDI",XPDA,"PKG",XP1,0))
+"RTN","XPDIA3",14,0)
+ S PE=$$FIND1^DIC(9.4,,"MX",$P(PN,U,2)) ;Get the IEN of the package
+"RTN","XPDIA3",15,0)
+ S OLDA=0,ROOT=$NA(^XTMP("XPDI",XPDA,"KRN",8989.5))
+"RTN","XPDIA3",16,0)
+ F  S OLDA=$O(@ROOT@(OLDA)) Q:'OLDA  D
+"RTN","XPDIA3",17,0)
+ . S XP1=@ROOT@(OLDA,0)
+"RTN","XPDIA3",18,0)
+ . S $P(XP1,U,1)=PE_";DIC(9.4," ;entity
+"RTN","XPDIA3",19,0)
+ . S $P(XP1,U,2)=$$LK^XPDIA($NA(^XTV(8989.51)),$P(XP1,U,2))
+"RTN","XPDIA3",20,0)
+ . S DA=$$LKPAR($P(XP1,U),$P(XP1,U,2),$P(XP1,U,3))
+"RTN","XPDIA3",21,0)
+ . ;Remove the current entry if we have one
+"RTN","XPDIA3",22,0)
+ . I DA>0 S DIK="^XTV(8989.5," D ^DIK
+"RTN","XPDIA3",23,0)
+ . ;Otherwise Add the zero node, See that we have a IEN
+"RTN","XPDIA3",24,0)
+ . I DA'>0 D ADDPAR($P(XP1,U),$P(XP1,U,2),$P(XP1,U,3)) S DA=$$LKPAR($P(XP1,U),$P(XP1,U,2),$P(XP1,U,3))
+"RTN","XPDIA3",25,0)
+ . Q:'DA  ;don't have a entry
+"RTN","XPDIA3",26,0)
+ . ;Merge the date ;with IHS fix
+"RTN","XPDIA3",27,0)
+ . M ^XTV(8989.5,DA)=^XTMP("XPDI",XPDA,"KRN",8989.5,OLDA)
+"RTN","XPDIA3",28,0)
+ . S ^XTV(8989.5,DA,0)=XP1 ;zero node with new pointers
+"RTN","XPDIA3",29,0)
+ . ;Get Definition and check if Data Type is pointer, then get pointed to global ref.
+"RTN","XPDIA3",30,0)
+ . S PT=$G(^XTV(8989.51,+$P(XP1,U,2),1)) D:$P(PT,U)="P"
+"RTN","XPDIA3",31,0)
+ . . S XP3=$G(^XTV(8989.5,DA,1)),PT=$P(PT,U,2)
+"RTN","XPDIA3",32,0)
+ . . S:PT $P(XP3,U)=$$FIND1^DIC(PT,"","X",$P(XP3,U)) ;resolve pointer value
+"RTN","XPDIA3",33,0)
+ . . S:$P(XP3,U) ^XTV(8989.5,DA,1)=XP3
+"RTN","XPDIA3",34,0)
+ . ;X-ref it
+"RTN","XPDIA3",35,0)
+ . S DIK="^XTV(8989.5," D IX1^DIK
+"RTN","XPDIA3",36,0)
+ Q
+"RTN","XPDIA3",37,0)
+ ;
+"RTN","XPDIA3",38,0)
+LKPAR(ENT,PAR,INST) ;Lookup an entry
+"RTN","XPDIA3",39,0)
+ Q $O(^XTV(8989.5,"AC",PAR,ENT,INST,0))
+"RTN","XPDIA3",40,0)
+ ;
+"RTN","XPDIA3",41,0)
+ADDPAR(ENT,PAR,INST) ;Add a parameter instance
+"RTN","XPDIA3",42,0)
+ N FDA,FDAIEN,DIERR
+"RTN","XPDIA3",43,0)
+ S FDA(8989.5,"+1,",.01)=ENT
+"RTN","XPDIA3",44,0)
+ S FDA(8989.5,"+1,",.02)=PAR
+"RTN","XPDIA3",45,0)
+ S FDA(8989.5,"+1,",.03)=INST
+"RTN","XPDIA3",46,0)
+ D UPDATE^DIE("","FDA","FDAIEN","DIERR")
+"RTN","XPDIA3",47,0)
+ Q
+"RTN","XPDIA3",48,0)
+ ;
+"RTN","XPDIA3",49,0)
+PAR1F1 ;PARAMETER File 8989.51: file Pre
+"RTN","XPDIA3",50,0)
+ Q
+"RTN","XPDIA3",51,0)
+PAR1E1 ;PARAMETER file 8989.51: entry pre
+"RTN","XPDIA3",52,0)
+ N XP1,XP2,XP3
+"RTN","XPDIA3",53,0)
+ S ^TMP($J,"XPD",DA)=""
+"RTN","XPDIA3",54,0)
+ ;if there is a new Description, kill the old Description
+"RTN","XPDIA3",55,0)
+ K:$O(^XTMP("XPDI",XPDA,"KRN",8989.51,OLDA,20,0)) ^XTV(8989.51,DA,20)
+"RTN","XPDIA3",56,0)
+ ;Kill any old Allowable entries
+"RTN","XPDIA3",57,0)
+ K:$O(^XTMP("XPDI",XPDA,"KRN",8989.51,OLDA,30,0)) ^XTV(8989.51,DA,30)
+"RTN","XPDIA3",58,0)
+ Q
+"RTN","XPDIA3",59,0)
+PAR1F2 ;PARAMETER file 8989.51: file post
+"RTN","XPDIA3",60,0)
+ N XPD,DIK,DA
+"RTN","XPDIA3",61,0)
+ S DA=0
+"RTN","XPDIA3",62,0)
+ F  S DA=$O(^TMP($J,"XPD",DA)) Q:'DA  D
+"RTN","XPDIA3",63,0)
+ . S DIK="^XTV(8989.51," D IX1^DIK
+"RTN","XPDIA3",64,0)
+ D PAR0F2 ;Go load the entries from 8989.5
+"RTN","XPDIA3",65,0)
+ Q
+"RTN","XPDIA3",66,0)
+PAR1DEL(RT) ;Delete Parameter Def entries
+"RTN","XPDIA3",67,0)
+ D DELPTR^XPDUTL1(8989.51,RT) ;Cleanup pointers
+"RTN","XPDIA3",68,0)
+ D DELIEN^XPDUTL1(8989.51,RT) ;Cleanup entries
+"RTN","XPDIA3",69,0)
+ Q
+"RTN","XPDIA3",70,0)
+ ;
+"RTN","XPDIA3",71,0)
+PAR2F1 ;PARAMETER TEMPLATE File 8989.52: file Pre
+"RTN","XPDIA3",72,0)
+ K ^TMP($J,"XPD")
+"RTN","XPDIA3",73,0)
+ Q
+"RTN","XPDIA3",74,0)
+PAR2E1 ;PARAMETER TEMPLATE file 8989.52: entry Pre
+"RTN","XPDIA3",75,0)
+ N XP1,XP2,ROOT
+"RTN","XPDIA3",76,0)
+ S ROOT=$NA(^XTMP("XPDI",XPDA,"KRN",8989.52))
+"RTN","XPDIA3",77,0)
+ S XP2=$P(@ROOT@(OLDA,0),U,4) ;Use instance of
+"RTN","XPDIA3",78,0)
+ ;Because we change the transport global see that a restart will work
+"RTN","XPDIA3",79,0)
+ I $L(XP2),XP2?1A.E S $P(@ROOT@(OLDA,0),U,4)=$$LK^XPDIA($NA(^XTV(8989.51)),XP2)
+"RTN","XPDIA3",80,0)
+ S XP1=0
+"RTN","XPDIA3",81,0)
+ F  S XP1=$O(@ROOT@(OLDA,10,XP1)),XP2="" Q:'XP1  D
+"RTN","XPDIA3",82,0)
+ . S XP2=$P(@ROOT@(OLDA,10,XP1,0),U,2) ;Parameter
+"RTN","XPDIA3",83,0)
+ . I $L(XP2),XP2?1A.E S $P(@ROOT@(OLDA,10,XP1,0),U,2)=$$LK^XPDIA($NA(^XTV(8989.51)),XP2)
+"RTN","XPDIA3",84,0)
+ . Q
+"RTN","XPDIA3",85,0)
+ ;kill the Parameter multiple at the site
+"RTN","XPDIA3",86,0)
+ K ^XTV(8989.52,DA,10)
+"RTN","XPDIA3",87,0)
+ Q
+"RTN","XPDIA3",88,0)
+PAR2F2 ;PARAMETER TEMPLATE file 8989.52: file Post
+"RTN","XPDIA3",89,0)
+ Q
+"RTN","XPDIA3",90,0)
+PAR2DEL(RT) ;Delete Parameter Templates
+"RTN","XPDIA3",91,0)
+ D DELIEN^XPDUTL1(8989.52,RT)
+"RTN","XPDIA3",92,0)
+ Q
+"RTN","XPDIA3",93,0)
+XULM ;XULM LOCK DICTIONARY file 8993; entry Pre
+"RTN","XPDIA3",94,0)
+ N XP1,XP2,ROOT
+"RTN","XPDIA3",95,0)
+ S ROOT=$NA(^XTMP("XPDI",XPDA,"KRN",8993))
+"RTN","XPDIA3",96,0)
+ ;repoint PACKAGE (1;1)
+"RTN","XPDIA3",97,0)
+ S XP1=$P($G(@ROOT@(OLDA,1)),U)
+"RTN","XPDIA3",98,0)
+ I XP1]"" S XP1=$$LK^XPDIA("^DIC(9.4)",XP1),$P(@ROOT@(OLDA,1),U)=XP1
+"RTN","XPDIA3",99,0)
+ ;check WP fields, if new then delete old at site
+"RTN","XPDIA3",100,0)
+ ;USAGE #4
+"RTN","XPDIA3",101,0)
+ K:$O(@ROOT@(OLDA,4,0)) ^XLM(8993,DA,4)
+"RTN","XPDIA3",102,0)
+ ;DESCRIPTION #2, under COMPUTABLE FILE REFERENCES #3 multiple
+"RTN","XPDIA3",103,0)
+ ;XP1 is a file number and is the same on all systems
+"RTN","XPDIA3",104,0)
+ S XP1=0
+"RTN","XPDIA3",105,0)
+ F  S XP1=$O(@ROOT@(OLDA,3,XP1)) Q:'XP1  I $O(^(XP1,2,0)) K ^XLM(8993,DA,3,XP1,2)
+"RTN","XPDIA3",106,0)
+ Q
+"RTN","XPDIGP")
+0^1^B15378428^B13701700
+"RTN","XPDIGP",1,0)
+XPDIGP ;SFISC/RSD - load Global Distribution ;08/25/2014
+"RTN","XPDIGP",2,0)
+ ;;8.0;KERNEL;**41,422,672**;Jul 10, 1995;Build 28
+"RTN","XPDIGP",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XPDIGP",4,0)
+ ;XPDT is undefine if PKG^XPDIL1 aborted, need to close device
+"RTN","XPDIGP",5,0)
+ I '$D(XPDT) D ^%ZISC Q
+"RTN","XPDIGP",6,0)
+ N %,XPD,XPDIST,XPDBLD,XPDNM
+"RTN","XPDIGP",7,0)
+ S XPDA=+XPDT(1),XPDNM=$P(XPDT(1),U,2),XPDBLD=$O(^XTMP("XPDI",XPDA,"BLD",0))
+"RTN","XPDIGP",8,0)
+ ;update Install file, read in the other globals, close device
+"RTN","XPDIGP",9,0)
+ D XPCK,GPI:'$G(XPDQUIT),^%ZISC
+"RTN","XPDIGP",10,0)
+ I $G(XPDQUIT) D ABRTALL^XPDI(1) Q
+"RTN","XPDIGP",11,0)
+ ;run post install routine
+"RTN","XPDIGP",12,0)
+ S XPD=$$INRTN^XPDIL1("INIT") I XPD]"" D
+"RTN","XPDIGP",13,0)
+ .;% = routine name only, remove tag
+"RTN","XPDIGP",14,0)
+ .S %=$P(XPD,U,$L(XPD,U)) Q:'$D(^XTMP("XPDI",XPDA,"RTN",%))
+"RTN","XPDIGP",15,0)
+ .W ! D SAVE^XPDIJ(%),BMES^XPDUTL(" Running Post Install routine "_XPD),@XPD
+"RTN","XPDIGP",16,0)
+ .;update Package file
+"RTN","XPDIGP",17,0)
+ ;XPDIST is flag for site tracking, it is set in PKG^XPDIP
+"RTN","XPDIGP",18,0)
+ S XPDIST=0 D BMES^XPDUTL(" Updating KIDS files... "),PKG^XPDIP
+"RTN","XPDIGP",19,0)
+ ;sends site tracking bulletin
+"RTN","XPDIGP",20,0)
+ ;I XPDIST S %=$$EN^XPDIST(XPDA) D BMES^XPDUTL(" "_$P("NO ",U,'%)_"Install Message sent to FORUM ") ; p672removed
+"RTN","XPDIGP",21,0)
+ I XPDIST S %=$$EN^XPDIST(XPDA) D BMES^XPDUTL(" "_$P("NO ",U,'$P(%,"#",2))_"Install Message sent "_%) ; p672 Send tracking message to Forum.
+"RTN","XPDIGP",22,0)
+ W !! D BMES^XPDUTL(" "_XPDNM_" Installed."),STMP^XPDIJ1(17) W !!
+"RTN","XPDIGP",23,0)
+ K ^XTMP("XPDI",XPDA),XPD
+"RTN","XPDIGP",24,0)
+ ;update the status field
+"RTN","XPDIGP",25,0)
+ S XPD(9.7,XPDA_",",.02)=3 D FILE^DIE("","XPD")
+"RTN","XPDIGP",26,0)
+ Q
+"RTN","XPDIGP",27,0)
+DISP ;display the contents
+"RTN","XPDIGP",28,0)
+ N X,Y,Z
+"RTN","XPDIGP",29,0)
+ W !,"This is a Global Distribution. It contains Global(s) that will",!,"update your system at this time. The following Global(s) will be installed:",!!
+"RTN","XPDIGP",30,0)
+ F Y=1:1 S X=$P(XPDGP,"^",Y) Q:X=""  D
+"RTN","XPDIGP",31,0)
+ .S Z=+$P(X,";"),X=$P(X,";",2),XPDT("GP",X)=Z_U_Y
+"RTN","XPDIGP",32,0)
+ .W "^"_X,?12,$P("Overwrite^Replace",U,Z+1),!
+"RTN","XPDIGP",33,0)
+ .;if unsubscripted global and replacing
+"RTN","XPDIGP",34,0)
+ .W:X'["("&Z "**WARNING - Global will be KILLED before install,",!,"Check global protection on ALL systems before continuing.",!
+"RTN","XPDIGP",35,0)
+ W !,"If you continue with the Load, the Global(s) will be",!,"Installed at this time.",!
+"RTN","XPDIGP",36,0)
+ Q
+"RTN","XPDIGP",37,0)
+GPI ;global package input
+"RTN","XPDIGP",38,0)
+ N DIRUT,GP,GR,X,XPDSEQ,Y,Z
+"RTN","XPDIGP",39,0)
+ ;start reading the HFS again,  rwf, changed all read timeout from 0 to 1.
+"RTN","XPDIGP",40,0)
+ U IO R X:10,Y:10
+"RTN","XPDIGP",41,0)
+ ;the next read must be the GLOBAL
+"RTN","XPDIGP",42,0)
+ I X'="**GLOBAL**" U IO(0) W !!,"ERROR in HFS file format!" S XPDQUIT=1 Q
+"RTN","XPDIGP",43,0)
+ U IO(0) D BMES^XPDUTL(" "_Y) U IO
+"RTN","XPDIGP",44,0)
+ ;XPDSEQ is the disk sequence number
+"RTN","XPDIGP",45,0)
+ S GP=$P(Y,U,2),GR=$S(Y[")":$E(Y,1,$L(Y)-1)_",",1:Y_"("),XPDSEQ=1
+"RTN","XPDIGP",46,0)
+ K:XPDT("GP",GP) @Y
+"RTN","XPDIGP",47,0)
+ ;X=global ref, Y=global value. DIRUT is when user is prompted for
+"RTN","XPDIGP",48,0)
+ ;next disk in NEXTD and they abort
+"RTN","XPDIGP",49,0)
+ F  R X:10,Y:10 Q:X="**END**"  D  I $D(DIRUT) S XPDQUIT=1 Q
+"RTN","XPDIGP",50,0)
+ .;new global
+"RTN","XPDIGP",51,0)
+ .I X="**GLOBAL**" D  Q
+"RTN","XPDIGP",52,0)
+ ..;completes last global check point
+"RTN","XPDIGP",53,0)
+ ..D XPCOM(GP,Y)
+"RTN","XPDIGP",54,0)
+ ..;reset global ref
+"RTN","XPDIGP",55,0)
+ ..S GP=$P(Y,U,2),GR=$S(Y[")":$E(Y,1,$L(Y)-1)_",",1:Y_"(")
+"RTN","XPDIGP",56,0)
+ ..;kill global if flag is set
+"RTN","XPDIGP",57,0)
+ ..K:XPDT("GP",GP) @Y
+"RTN","XPDIGP",58,0)
+ .;I X="**CONTINUE**" D NEXTD^XPDIL Q  ;X="**CONTINUE**" will only happen if the file was on multiple diskettes. 
+"RTN","XPDIGP",59,0)
+ .S @(GR_X)=Y
+"RTN","XPDIGP",60,0)
+ D XPCOM(GP)
+"RTN","XPDIGP",61,0)
+ U IO(0)
+"RTN","XPDIGP",62,0)
+ Q
+"RTN","XPDIGP",63,0)
+ ;
+"RTN","XPDIGP",64,0)
+ ;create Global multiple of Install file
+"RTN","XPDIGP",65,0)
+XPCK N DIR,DIRUT,X,XPD,XPDJ,X,Y,Z
+"RTN","XPDIGP",66,0)
+ S DIR(0)="Y",DIR("A")="Globals will now be installed, OK",DIR("B")="YES",DIR("?")="YES will continue with install, NO will abort install"
+"RTN","XPDIGP",67,0)
+ W ! D ^DIR I $D(DIRUT)!'Y S XPDQUIT=1 Q
+"RTN","XPDIGP",68,0)
+ W ! D BMES^XPDUTL(" Install Started for "_XPDNM_" : "),STMP^XPDIJ1(11),BMES^XPDUTL(" Installing Globals:")
+"RTN","XPDIGP",69,0)
+ S X=""
+"RTN","XPDIGP",70,0)
+ F  S X=$O(XPDT("GP",X)) Q:X=""  S Z=$P(XPDT("GP",X),U,2),XPD(9.718,"+"_Z_","_XPDA_",",.01)=X,XPDJ(Z)=Z
+"RTN","XPDIGP",71,0)
+ D:$D(XPD)>9 UPDATE^DIE("S","XPD","XPDJ")
+"RTN","XPDIGP",72,0)
+ Q
+"RTN","XPDIGP",73,0)
+ ;
+"RTN","XPDIGP",74,0)
+XPCOM(X,XPDN) ;complete checkpoint for global X,XPDN=next global
+"RTN","XPDIGP",75,0)
+ N GR,GP,XPD,Y,Z
+"RTN","XPDIGP",76,0)
+ U IO(0)
+"RTN","XPDIGP",77,0)
+ S Y=$$NOW^XLFDT,Z=+$P(XPDT("GP",X),U,2),XPD(9.718,Z_","_XPDA_",",1)=Y
+"RTN","XPDIGP",78,0)
+ D MES^XPDUTL("               "_$$FMTE^XLFDT(Y)),FILE^DIE("","XPD")
+"RTN","XPDIGP",79,0)
+ D:$L($G(XPDN)) BMES^XPDUTL(" "_XPDN)
+"RTN","XPDIGP",80,0)
+ U IO
+"RTN","XPDIGP",81,0)
+ Q
+"RTN","XPDIJ")
+0^4^B25041581^B23600088
+"RTN","XPDIJ",1,0)
+XPDIJ ;SFISC/RSD - Install Job ;08/14/2008
+"RTN","XPDIJ",2,0)
+ ;;8.0;KERNEL;**2,21,28,41,44,68,81,95,108,124,229,275,506,672**;Jul 10, 1995;Build 28
+"RTN","XPDIJ",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XPDIJ",4,0)
+EN ;install all packages
+"RTN","XPDIJ",5,0)
+ ;XPDA=ien of first package
+"RTN","XPDIJ",6,0)
+ ;this is needed to restore XPDIJ1
+"RTN","XPDIJ",7,0)
+ D LNRF("XPDUTL") ;p275 SAVE calls RTNLOG^XPDUTL
+"RTN","XPDIJ",8,0)
+ D LNRF("XPDIJ1") ;See that XPDIJ1 is loaded befor it is called
+"RTN","XPDIJ",9,0)
+ N IEN,XPDI,XPD0,XPDSET,XPDABORT,XPDMENU,XPDQUIT,XPDVOL,X,Y,ZTRTN,ZTDTH,ZTIO,ZTDESC,ZTSK
+"RTN","XPDIJ",10,0)
+ M X=DUZ N DUZ M DUZ=X S DUZ(0)="@" ;See that install has full FM priv.
+"RTN","XPDIJ",11,0)
+ I $$NEWERR^%ZTER N $ETRAP,$ESTACK S $ETRAP="D ERR^XPDIJ"
+"RTN","XPDIJ",12,0)
+ E  S X="ERR^XPDIJ",@^%ZOSF("TRAP")
+"RTN","XPDIJ",13,0)
+ ;check that Install entry exists, set status to "Start of Install"
+"RTN","XPDIJ",14,0)
+ Q:'$D(^XPD(9.7,+$G(XPDA),0))  S XPD0=^(0),$P(^(0),U,9)=2
+"RTN","XPDIJ",15,0)
+ D INIT^XPDID
+"RTN","XPDIJ",16,0)
+ ;See if need to Inhibit Logons
+"RTN","XPDIJ",17,0)
+ I $$ANSWER^XPDIQ("XPI1") D INHIBIT^XPDIJ1("Y")
+"RTN","XPDIJ",18,0)
+ ;disable options & protocols for setname, XPDSET=1/0^setname^out of order msg.
+"RTN","XPDIJ",19,0)
+ S Y=$P(XPD0,U,8),XPDSET=+Y_U_$E(Y,2,99)_U_$S($L(Y):$P($G(^XTMP("XQOO",$E(Y,2,99),0)),U),1:"")
+"RTN","XPDIJ",20,0)
+ ;hang the number of seconds given in 0;10
+"RTN","XPDIJ",21,0)
+ I XPDSET D OFF^XQOO1($P(XPDSET,U,2)) I $P(XPD0,U,10) H ($P(XPD0,U,10)*60)
+"RTN","XPDIJ",22,0)
+ ;check that Install still exists, wasn't unloaded p672
+"RTN","XPDIJ",23,0)
+ I '$D(^XPD(9.7,XPDA,0))!'$D(^XTMP("XPDI",XPDA)) D EXIT^XPDID(" Build NOT installed, Transport Global missing!!!!") Q
+"RTN","XPDIJ",24,0)
+ S Y=0
+"RTN","XPDIJ",25,0)
+ ;XPDABORT can be set in pre or post install to abort install
+"RTN","XPDIJ",26,0)
+ F  S Y=$O(^XPD(9.7,"ASP",XPDA,Y)) Q:'Y  S %=$O(^(Y,0)) D:%  Q:$D(XPDABORT)
+"RTN","XPDIJ",27,0)
+ .N XPD,XPDA,XPDNM,XPDV,XPDV0,XPDVOL,XPDX,XPDY,Y
+"RTN","XPDIJ",28,0)
+ .;Now do the Install
+"RTN","XPDIJ",29,0)
+ .S XPDA=%,XPDNM=$P($G(^XPD(9.7,XPDA,0)),U) D IN^XPDIJ1 Q:$D(XPDABORT)
+"RTN","XPDIJ",30,0)
+ ;
+"RTN","XPDIJ",31,0)
+ ;Now do Master Build Post INIT.
+"RTN","XPDIJ",32,0)
+ I '$D(XPDABORT),$D(XPDT("MASTER")) D
+"RTN","XPDIJ",33,0)
+ .N XPDBLD,XPDGREF
+"RTN","XPDIJ",34,0)
+ .S XPDBLD=$O(^XTMP("XPDI",XPDA,"BLD",0)),XPDGREF="^XTMP(""XPDI"","_XPDA_",""TEMP"")"
+"RTN","XPDIJ",35,0)
+ .D POST^XPDIJ1
+"RTN","XPDIJ",36,0)
+ ;ZTREQ tells taskman to delete task
+"RTN","XPDIJ",37,0)
+ I $G(ZTSK) S ZTREQ="@" D
+"RTN","XPDIJ",38,0)
+ .;remove task # from Install File
+"RTN","XPDIJ",39,0)
+ .N XPD S XPD(9.7,XPDA_",",5)="@"
+"RTN","XPDIJ",40,0)
+ .D FILE^DIE("","XPD")
+"RTN","XPDIJ",41,0)
+ ;quit if install was aborted
+"RTN","XPDIJ",42,0)
+ I $D(XPDABORT) D EXIT^XPDID("Install Aborted!!"),^%ZISC Q
+"RTN","XPDIJ",43,0)
+ ;put option back in order
+"RTN","XPDIJ",44,0)
+ I $P(XPDSET,U,2)]"" D ON^XQOO1($P(XPDSET,U,2)) K ^XTMP("XQOO",$P(XPDSET,U,2))
+"RTN","XPDIJ",45,0)
+ ;check if menu rebuild is wanted (only if option has been added to any installs)
+"RTN","XPDIJ",46,0)
+ ;XPDMENU is used to check that it is only done once
+"RTN","XPDIJ",47,0)
+ S (Y,XPDMENU)=0
+"RTN","XPDIJ",48,0)
+ F  S Y=$O(^XPD(9.7,"ASP",XPDA,Y)) Q:'Y  S %=$O(^(Y,0)) D:%  Q:XPDMENU
+"RTN","XPDIJ",49,0)
+ .N XPDA,Y
+"RTN","XPDIJ",50,0)
+ .S XPDA=%
+"RTN","XPDIJ",51,0)
+ .I $$ANSWER^XPDIQ("XPO1") D BMES^XPDUTL(" Call MENU rebuild"),KIDS^XQ81 S XPDMENU=1
+"RTN","XPDIJ",52,0)
+ .;There should be no reason to check other CPUs anymore, patch 496
+"RTN","XPDIJ",53,0)
+ .Q
+"RTN","XPDIJ",54,0)
+ .;check if need to queue menu rebuild on other CPUs
+"RTN","XPDIJ",55,0)
+ .D:$O(^XPD(9.7,XPDA,"VOL",0))
+"RTN","XPDIJ",56,0)
+ ..N XPDU,XPDY,XPDV,XPDV0,ZTUCI,ZTCPU
+"RTN","XPDIJ",57,0)
+ ..X ^%ZOSF("UCI") S XPDU=$P(Y,","),XPDY=$P(Y,",",2),XPDV=0
+"RTN","XPDIJ",58,0)
+ ..;loop thru VOLUMES SET and don't do current volume set
+"RTN","XPDIJ",59,0)
+ ..F  S XPDV=$O(^XPD(9.7,XPDA,"VOL",XPDV)) Q:'XPDV  S XPDV0=$P(^(XPDV,0),U) D:XPDV0'=XPDY
+"RTN","XPDIJ",60,0)
+ ...S ZTUCI=XPDU,ZTDTH=$H,ZTIO="",ZTDESC="Install Menu Rebuild",ZTCPU=XPDV0,ZTRTN="KIDS^XQ81" D ^%ZTLOAD
+"RTN","XPDIJ",61,0)
+ ;
+"RTN","XPDIJ",62,0)
+ ;See if need to reset inhibit logons
+"RTN","XPDIJ",63,0)
+ I $$ANSWER^XPDIQ("XPI1") D INHIBIT^XPDIJ1("N")
+"RTN","XPDIJ",64,0)
+ ;
+"RTN","XPDIJ",65,0)
+ ;clean up globals
+"RTN","XPDIJ",66,0)
+ S Y=0
+"RTN","XPDIJ",67,0)
+ F  S Y=$O(^XPD(9.7,"ASP",XPDA,Y)) Q:'Y  S XPDI=$O(^(Y,0)) D:XPDI
+"RTN","XPDIJ",68,0)
+ . N %,Y,XPD,X
+"RTN","XPDIJ",69,0)
+ . ;See if need to delete Env,Pre,Post routines.
+"RTN","XPDIJ",70,0)
+ . S %=$O(^XTMP("XPDI",XPDI,"BLD",0)),XPD=$G(^XTMP("XPDI",XPDI,"BLD",%,"INID"))
+"RTN","XPDIJ",71,0)
+ . I '$$GET^XUPARAM("XPD NO_EPP_DELETE") F %=1:1:3 I $P(XPD,U,%)="y" D
+"RTN","XPDIJ",72,0)
+ . . S X=^XTMP("XPDI",XPDI,$P("PRE^INIT^INI",U,%)) S:X[U X=$P(X,U,2) X:X]"" ^%ZOSF("DEL")
+"RTN","XPDIJ",73,0)
+ . ;kill transport global
+"RTN","XPDIJ",74,0)
+ . K ^XTMP("XPDI",XPDI)
+"RTN","XPDIJ",75,0)
+ . ;update the status field
+"RTN","XPDIJ",76,0)
+ . S XPD(9.7,XPDI_",",.02)=3
+"RTN","XPDIJ",77,0)
+ . D FILE^DIE("","XPD")
+"RTN","XPDIJ",78,0)
+ D EXIT^XPDID("Install Completed"),^%ZISC
+"RTN","XPDIJ",79,0)
+ Q
+"RTN","XPDIJ",80,0)
+ ;
+"RTN","XPDIJ",81,0)
+SAVE(X) ;restore routine X
+"RTN","XPDIJ",82,0)
+ N %,DIE,XCM,XCN,XCS
+"RTN","XPDIJ",83,0)
+ S DIE="^XTMP(""XPDI"",XPDA,""RTN"",X,",XCN=0
+"RTN","XPDIJ",84,0)
+ X ^%ZOSF("SAVE") D RTNLOG^XPDUTL(X)
+"RTN","XPDIJ",85,0)
+ Q
+"RTN","XPDIJ",86,0)
+RTN(XPDA) ;restore all routines for package XPDA
+"RTN","XPDIJ",87,0)
+ ;^XPD("XPDI",XPDA,"RTN",routine name)=0-install, 1-delete, 2-skip^checksum
+"RTN","XPDIJ",88,0)
+ Q:$G(XPDA)=""
+"RTN","XPDIJ",89,0)
+ N X,XPDI,XPDJ S XPDI=""
+"RTN","XPDIJ",90,0)
+ F  S XPDI=$O(^XTMP("XPDI",XPDA,"RTN",XPDI)) Q:XPDI=""  S XPDJ=^(XPDI) D
+"RTN","XPDIJ",91,0)
+ .;if we are doing VT graphic display, set counter
+"RTN","XPDIJ",92,0)
+ .I $D(XPDIDVT) S XPDIDCNT=XPDIDCNT+1 D:'(XPDIDCNT#XPDIDMOD) UPDATE^XPDID(XPDIDCNT)
+"RTN","XPDIJ",93,0)
+ .I 'XPDJ D SAVE(XPDI) Q
+"RTN","XPDIJ",94,0)
+ .;set checksum to null, since routine wasn't loaded
+"RTN","XPDIJ",95,0)
+ .I $P(XPDJ,U,2) S $P(^XTMP("XPDI",XPDA,"BLD",XPDBLD,"KRN",9.8,"NM",$P(XPDJ,U,2),0),U,4)=""
+"RTN","XPDIJ",96,0)
+ .I $P(XPDJ,U)=1 S X=XPDI X ^%ZOSF("DEL")
+"RTN","XPDIJ",97,0)
+ ;if graphic display, update full count
+"RTN","XPDIJ",98,0)
+ I $D(XPDIDVT) D UPDATE^XPDID(XPDIDCNT)
+"RTN","XPDIJ",99,0)
+ Q
+"RTN","XPDIJ",100,0)
+ ;
+"RTN","XPDIJ",101,0)
+VOLERR(V,F) ;volume set not updated,V=volume set, F=flag
+"RTN","XPDIJ",102,0)
+ N XQA,XQAMSG,XPDMES
+"RTN","XPDIJ",103,0)
+ S XPDMES(1)=" ",XPDMES(2)=" ** Job on VOLUME SET "_V_$S(F:" never started **",1:" has been idle for an hour.")
+"RTN","XPDIJ",104,0)
+ S XPDMES(3)=" ** "_V_" has NOT been updated! **"
+"RTN","XPDIJ",105,0)
+ S XQA(DUZ)="",XQAMSG="VOLUME SET "_V_" NOT updated for Install "_$E($P($G(^XPD(9.7,+$G(XPDA),0)),"^"),1,30)
+"RTN","XPDIJ",106,0)
+ D MES^XPDUTL(.XPDMES),SETUP^XQALERT
+"RTN","XPDIJ",107,0)
+ Q
+"RTN","XPDIJ",108,0)
+ ;come here on error, record error in Install file and cleanup var.
+"RTN","XPDIJ",109,0)
+ERR N XPDERROR,XQA,XQAMSG
+"RTN","XPDIJ",110,0)
+ S XPDERROR=$$EC^%ZOSV
+"RTN","XPDIJ",111,0)
+ ;record error, write message, reset terminal
+"RTN","XPDIJ",112,0)
+ D ^%ZTER,BMES^XPDUTL(XPDERROR),EXIT^XPDID()
+"RTN","XPDIJ",113,0)
+ S XQA(DUZ)="",XQAMSG="Install "_$E($P($G(^XPD(9.7,+$G(XPDA),0)),"^"),1,30)_" has encountered an Error."
+"RTN","XPDIJ",114,0)
+ D SETUP^XQALERT G UNWIND^%ZTER
+"RTN","XPDIJ",115,0)
+ ;
+"RTN","XPDIJ",116,0)
+LNRF(RN) ;Load needed routines first
+"RTN","XPDIJ",117,0)
+ I $D(^XTMP("XPDI",XPDA,"RTN",RN)) D
+"RTN","XPDIJ",118,0)
+ .N X
+"RTN","XPDIJ",119,0)
+ .D SAVE(RN)
+"RTN","XPDIJ",120,0)
+ .S XCN=$$RTNUP^XPDUTL(RN,2)
+"RTN","XPDIJ",121,0)
+ Q
+"RTN","XPDIK")
+0^17^B45151148^B39787924
+"RTN","XPDIK",1,0)
+XPDIK ;SFISC/RSD - Install Kernel Files & FM Files ;04/26/2004  11:20
+"RTN","XPDIK",2,0)
+ ;;8.0;KERNEL;**15,58,108,124,146,346,672**;Jul 10, 1995;Build 28
+"RTN","XPDIK",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XPDIK",4,0)
+ Q
+"RTN","XPDIK",5,0)
+KRN ;
+"RTN","XPDIK",6,0)
+ ;XPDA=package ien in INSTALL FILE, XPDNM=package name, XPDCP= check points
+"RTN","XPDIK",7,0)
+ N DA,DIC,DIOVRD,EPOS,EPRE,FDEL,FPOS,FPRE,OLDA,ORD,X,XGCEDITR,XPDDR,XPDFIL,XPDFILNM,XPDFL,XPDNEW,XREF,Y,Z,%
+"RTN","XPDIK",8,0)
+ ;DIOVRD is used to override write protection on a file
+"RTN","XPDIK",9,0)
+ ;XGCEDITR is check in file 8995, at 'SCR' node of DD
+"RTN","XPDIK",10,0)
+ S ORD=0,XPDCP="KRN",(DIOVRD,XGCEDITR)=1
+"RTN","XPDIK",11,0)
+ F  S ORD=$O(^XTMP("XPDI",XPDA,"ORD",ORD)) Q:'ORD  S XPDFIL=+$O(^(ORD,0)),XREF=$G(^(XPDFIL)),XPDFILNM=$G(^(XPDFIL,0)) D:XPDFIL
+"RTN","XPDIK",12,0)
+ .;sets up EPOS,EPRE,FDEL,FPOS,FPRE variables
+"RTN","XPDIK",13,0)
+ .F DA=1:1:5 S @$P("FPRE^EPRE^FPOS^EPOS^FDEL",U,DA)=$P(XREF,";",DA+5)
+"RTN","XPDIK",14,0)
+ .K DIC,^TMP($J,"XPDEL"),XPDDR
+"RTN","XPDIK",15,0)
+ .S DIC=$G(^DIC(XPDFIL,0,"GL")),XREF=+$P(XREF,";",3)
+"RTN","XPDIK",16,0)
+ .;check if file, XPDFIL, exist at this site
+"RTN","XPDIK",17,0)
+ .I $P($G(^DIC(XPDFIL,0)),U)'=XPDFILNM D BMES^XPDUTL(" File "_XPDFIL_" is not "_XPDFILNM_", nothing installed.") Q
+"RTN","XPDIK",18,0)
+ .;check if XPDFIL has already been installed
+"RTN","XPDIK",19,0)
+ .I $P(^XPD(9.7,XPDA,"KRN",XPDFIL,0),U,2) D BMES^XPDUTL(" "_XPDFILNM_" already installed.") Q
+"RTN","XPDIK",20,0)
+ .D BMES^XPDUTL(" Installing "_XPDFILNM),SETTOT^XPDID(XPDFIL)
+"RTN","XPDIK",21,0)
+ .;do File Pre-install action, continue if ok
+"RTN","XPDIK",22,0)
+ .;XPDFL= 0-send,1-delete,2-link,3-merge,4-attach,5-disable
+"RTN","XPDIK",23,0)
+ .;loops thru the entries for this file
+"RTN","XPDIK",24,0)
+ .I '$$ACT(FPRE) S OLDA=0 F  S OLDA=$O(^XTMP("XPDI",XPDA,"KRN",XPDFIL,OLDA)) Q:'OLDA  S XPDFL=+$G(^(OLDA,-1)),OLDA(0)=^(0) D
+"RTN","XPDIK",25,0)
+ ..;if we are doing VT graphic display, set counter
+"RTN","XPDIK",26,0)
+ ..I $D(XPDIDVT) S XPDIDCNT=XPDIDCNT+1 D:'(XPDIDCNT#XPDIDMOD) UPDATE^XPDID(XPDIDCNT)
+"RTN","XPDIK",27,0)
+ ..;quit if disable or attach (4 or 5).  Attach will be processed under the parent menu.
+"RTN","XPDIK",28,0)
+ ..Q:XPDFL>3
+"RTN","XPDIK",29,0)
+ ..;if FM file, need to set screening logic
+"RTN","XPDIK",30,0)
+ ..I XPDFIL<.44 S %=$S(XPDFIL'=.403:4,1:8),DIC("S")="I $P(^(0),U,"_%_")="_$P(OLDA(0),U,%)
+"RTN","XPDIK",31,0)
+ ..;if deleting at site and a template, reset the lookup value and DIC("S")
+"RTN","XPDIK",32,0)
+ ..I XPDFL=1,XPDFIL<.44 S %=$P(OLDA(0),U),$P(OLDA(0),U)=$P(%,"    FILE #"),DIC("S")="I $P(^(0),U,"_$S(XPDFIL'=.403:4,1:8)_")="_+$P(%,"    FILE #",2)
+"RTN","XPDIK",33,0)
+ ..;XPDNEW=1 if entry is new, laygo
+"RTN","XPDIK",34,0)
+ ..S X=$P(OLDA(0),U),Y=$$DIC(XPDFIL,X,$G(DIC("S")),XPDFL,.XPDDR) Q:'Y  S DA=+Y,XPDNEW=$P(Y,U,3)
+"RTN","XPDIK",35,0)
+ ..;if deleting then save and process after FPOS
+"RTN","XPDIK",36,0)
+ ..I XPDFL=1 S ^TMP($J,"XPDEL",DA)="" Q
+"RTN","XPDIK",37,0)
+ ..;do Entries Pre-install action
+"RTN","XPDIK",38,0)
+ ..Q:$$ACT(EPRE)
+"RTN","XPDIK",39,0)
+ ..;merges the data, if you want the data deleted before the merge, you must
+"RTN","XPDIK",40,0)
+ ..;do it in the Entry Pre-install node, EPRE.
+"RTN","XPDIK",41,0)
+ ..M @(DIC_DA_")")=^XTMP("XPDI",XPDA,"KRN",XPDFIL,OLDA)
+"RTN","XPDIK",42,0)
+ ..;kill the flag node from the live data node
+"RTN","XPDIK",43,0)
+ ..K @(DIC_DA_",-1)") Q:$$ACT(EPOS)
+"RTN","XPDIK",44,0)
+ ..;XREF is flag to x-ref file after each entry, it is set in file 9.6
+"RTN","XPDIK",45,0)
+ ..I XREF N DIK S DIK=DIC D IX1^DIK
+"RTN","XPDIK",46,0)
+ .;do File Post Install Action
+"RTN","XPDIK",47,0)
+ .S %=$$ACT(FPOS)
+"RTN","XPDIK",48,0)
+ .;process the deleting of entries, FDEL should allow the passing of all entries
+"RTN","XPDIK",49,0)
+ .;to delete in array ^TMP($J,"XPDEL",DA)=""
+"RTN","XPDIK",50,0)
+ .I $L(FDEL),$D(^TMP($J,"XPDEL")) S %="^TMP($J,""XPDEL"")" D @FDEL
+"RTN","XPDIK",51,0)
+ .;complete check point
+"RTN","XPDIK",52,0)
+ .S %=$$XPCOM(XPDFIL)
+"RTN","XPDIK",53,0)
+ .K ^TMP($J,"XPDEL")
+"RTN","XPDIK",54,0)
+ .I $D(XPDIDVT) D UPDATE^XPDID(XPDIDCNT)
+"RTN","XPDIK",55,0)
+ Q
+"RTN","XPDIK",56,0)
+FIA ;
+"RTN","XPDIK",57,0)
+ ;XPFIL2=file is new^DD screen failed^data already exists^change file name^don't add data; 1=yes, 0=no
+"RTN","XPDIK",58,0)
+ N XPGR,XPFIL,XPFILO,XPFIL2,Z
+"RTN","XPDIK",59,0)
+ S XPFIL=0,XPGR=$NA(^XTMP("XPDI",XPDA))
+"RTN","XPDIK",60,0)
+ F  S XPFIL=$O(^XTMP("XPDI",XPDA,"FIA",XPFIL)) Q:'XPFIL  S XPFILO=^(XPFIL,0,1),XPFIL2=^(2) D
+"RTN","XPDIK",61,0)
+ .;if we are doing VT graphic display, set counter
+"RTN","XPDIK",62,0)
+ .I $D(XPDIDVT) S XPDIDCNT=XPDIDCNT+1 D:'(XPDIDCNT#XPDIDMOD) UPDATE^XPDID(XPDIDCNT)
+"RTN","XPDIK",63,0)
+ .;file is new, alway install DD
+"RTN","XPDIK",64,0)
+ .S:XPFIL2 $P(XPFILO,U)="y",$P(^XTMP("XPDI",XPDA,"FIA",XPFIL,0,1),U)="y"
+"RTN","XPDIK",65,0)
+ .;DD failed screen
+"RTN","XPDIK",66,0)
+ .I $P(XPFIL2,U,2) D  Q
+"RTN","XPDIK",67,0)
+ ..N XPD
+"RTN","XPDIK",68,0)
+ ..S XPD(1)=" ",XPD(2)="Data Dictionary for File #"_XPFIL_" not installed, failed DD screen."
+"RTN","XPDIK",69,0)
+ ..D MES^XPDUTL(.XPD) S %=$$XPCOM(XPFIL)
+"RTN","XPDIK",70,0)
+ .;if udate DD question = no & file is not new update checkpoint
+"RTN","XPDIK",71,0)
+ .I $P(XPFILO,U)'="y"&'XPFIL2 S %=$$XPCOM(XPFIL)
+"RTN","XPDIK",72,0)
+ .;check if XPFIL has already been installed
+"RTN","XPDIK",73,0)
+ .Q:$P(^XPD(9.7,XPDA,4,XPFIL,0),U,2)
+"RTN","XPDIK",74,0)
+ .;update file name
+"RTN","XPDIK",75,0)
+ .I $P(XPFIL2,U,4) D
+"RTN","XPDIK",76,0)
+ ..N DIE,DR,DA
+"RTN","XPDIK",77,0)
+ ..S DR=".01////"_^XTMP("XPDI",XPDA,"FIA",XPFIL),DA=XPFIL,DIE=1
+"RTN","XPDIK",78,0)
+ ..D ^DIE
+"RTN","XPDIK",79,0)
+ .;move DD and check for errors
+"RTN","XPDIK",80,0)
+ .D DDIN^DIFROMS(XPFIL,"","",XPGR),DIERR("** ERROR IN DATA DICTIONARY FOR FILE # "_XPFIL_" **"):$D(DIERR)
+"RTN","XPDIK",81,0)
+ .S %=$$XPCOM(XPFIL)
+"RTN","XPDIK",82,0)
+ I $D(XPDIDVT) D UPDATE^XPDID(XPDIDTOT)
+"RTN","XPDIK",83,0)
+ Q
+"RTN","XPDIK",84,0)
+DAT ;
+"RTN","XPDIK",85,0)
+ N XPGR,XPFIL,XPFILO,XPFIL2,Z
+"RTN","XPDIK",86,0)
+ S XPFIL=0,XPGR=$NA(^XTMP("XPDI",XPDA))
+"RTN","XPDIK",87,0)
+ ;DO if they are sending data
+"RTN","XPDIK",88,0)
+ F  S XPFIL=$O(^XTMP("XPDI",XPDA,"FIA",XPFIL)) Q:'XPFIL  S XPFILO=^(XPFIL,0,1),XPFIL2=^(2) D:$P(XPFILO,U,7)="y"
+"RTN","XPDIK",89,0)
+ .;DD failed screen or answer no to adding data or 'Add if new' & data already exists or file doesn't exist
+"RTN","XPDIK",90,0)
+ .I $P(XPFIL2,U,2)!$P(XPFIL2,U,5)!($P(XPFILO,U,8)="a"&$P(XPFIL2,U,3))!'$D(^DIC(XPFIL,0)) S %=$$XPCOM(XPFIL,1) Q
+"RTN","XPDIK",91,0)
+ .;check if XPFIL has already been installed or no data to input
+"RTN","XPDIK",92,0)
+ .Q:$P(^XPD(9.7,XPDA,4,XPFIL,0),U,3)!('$D(^XTMP("XPDI",XPDA,"DATA",XPFIL)))
+"RTN","XPDIK",93,0)
+ .;bring in Data and check for error
+"RTN","XPDIK",94,0)
+ .D DATAIN^DIFROMS(XPFIL,"","",XPGR),DIERR("** ERROR IN DATA FOR FILE # "_XPFIL_" **"):$D(DIERR)
+"RTN","XPDIK",95,0)
+ .S %=$$XPCOM(XPFIL,1)
+"RTN","XPDIK",96,0)
+ D RP^DIFROMSR("","",XPGR),DIERR("** ERROR IN POINTER RESOLUTION OF DATA **"):$D(DIERR)
+"RTN","XPDIK",97,0)
+ Q
+"RTN","XPDIK",98,0)
+ ;record error
+"RTN","XPDIK",99,0)
+DIERR(XPDI) N XPD
+"RTN","XPDIK",100,0)
+ D MSG^DIALOG("AE",.XPD) Q:'$D(XPD)
+"RTN","XPDIK",101,0)
+ D BMES^XPDUTL(XPDI),MES^XPDUTL(.XPD)
+"RTN","XPDIK",102,0)
+ Q
+"RTN","XPDIK",103,0)
+ ;
+"RTN","XPDIK",104,0)
+ ;XPDF=file #,XPDX=input X,XPDS=screen logic, XPDACT=action, XPDDR(field)=indirect string; add required identifiers
+"RTN","XPDIK",105,0)
+DIC(XPDF,XPDX,XPDS,XPDACT,XPDDR) ;
+"RTN","XPDIK",106,0)
+ N DIC,DIERR,XPD,XPDN
+"RTN","XPDIK",107,0)
+ S DIC=$G(^DIC(XPDF,0,"GL"))
+"RTN","XPDIK",108,0)
+ D FIND^DIC(XPDF,"","","XQf",XPDX,5,"",$G(XPDS),"","XPD")
+"RTN","XPDIK",109,0)
+ ;one or more matches, just return first one
+"RTN","XPDIK",110,0)
+ I $G(XPD(0)) D:XPD(0)>1  Q XPD(1)
+"RTN","XPDIK",111,0)
+ .S %(1)=$P($G(^DIC(XPDF,0)),U)_"  "_XPDX_"  is Duplicated,",%(2)=" only ien #"_XPD(1)_" was updated."
+"RTN","XPDIK",112,0)
+ .D MES^XPDUTL(.%)
+"RTN","XPDIK",113,0)
+ ;no match and action=(delete,link, or attach), don't write message if deleting
+"RTN","XPDIK",114,0)
+ I $G(XPDACT),XPDACT'=3 D:XPDACT'=1 BMES^XPDUTL(" "_$P($G(^DIC(XPDF,0)),U)_" "_XPDX_" Lookup failed, NO Action Taken.") Q 0
+"RTN","XPDIK",115,0)
+ ;add a new entry
+"RTN","XPDIK",116,0)
+ N DLAYGO,X,Y,Z
+"RTN","XPDIK",117,0)
+ ;S X=XPDX,DIC(0)="LX",DLAYGO=XPDF,DIC("S")=$G(XPDS)
+"RTN","XPDIK",118,0)
+ ;D ^DIC
+"RTN","XPDIK",119,0)
+ ;I Y<0 D BMES^XPDUTL(" "_$P($G(^DIC(XPDF,0)),U)_" "_XPDX_" **Couldn't Add to file**") Q 0
+"RTN","XPDIK",120,0)
+ ;Q Y
+"RTN","XPDIK",121,0)
+ ;code can't be used until UPDATE^DIE allows the creation of a record
+"RTN","XPDIK",122,0)
+ ;without required identifiers
+"RTN","XPDIK",123,0)
+ K XPD,DIERR
+"RTN","XPDIK",124,0)
+ S XPD(XPDF,"+1,",.01)=XPDX,XPDDR=0
+"RTN","XPDIK",125,0)
+ ;XPDDR is an array that contains field # and indirection code to add an identifier field during a new record
+"RTN","XPDIK",126,0)
+ ;XPDDR(1)="$P(OLDA(0),U,2)" for file 19, add Menu Text #1 
+"RTN","XPDIK",127,0)
+ F  S XPDDR=$O(XPDDR(XPDDR)) Q:'XPDDR  S Z="XPD(XPDF,""+1,"",XPDDR)="_XPDDR(XPDDR),@Z
+"RTN","XPDIK",128,0)
+ D UPDATE^DIE("E","XPD","XPDN") ;p672
+"RTN","XPDIK",129,0)
+ ;couldn't add as new
+"RTN","XPDIK",130,0)
+ I $D(DIERR) D DIERR(" "_$P($G(^DIC(XPDF,0)),U)_" "_XPDX_" **Couldn't Add to file**") Q 0
+"RTN","XPDIK",131,0)
+ I '$G(XPDN(1)) D BMES^XPDUTL(" "_$P($G(^DIC(XPDF,0)),U)_" "_XPDX_" **Couldn't Add to file**") Q 0
+"RTN","XPDIK",132,0)
+ ;"^^1" indicates new entry, same as Y in DIC call p672
+"RTN","XPDIK",133,0)
+ Q XPDN(1)_"^^1"
+"RTN","XPDIK",134,0)
+ ;
+"RTN","XPDIK",135,0)
+ACT(%) ;execute action, returns 0 to continue, 1 to quit
+"RTN","XPDIK",136,0)
+ ;user can count on DIC,DA,XPDFIL,OLDA,XPDNM,XPDFL,X,Y being around
+"RTN","XPDIK",137,0)
+ ;XPDNEW is set only for Entry Pre-install action
+"RTN","XPDIK",138,0)
+ Q:%="" 0
+"RTN","XPDIK",139,0)
+ N %1,%2,%3,%4,%5
+"RTN","XPDIK",140,0)
+ S %1=$G(DIC),%2=$G(DA),%3=$G(OLDA),%4=$P(%,U),%5=$P($P(%,U,2),"(")
+"RTN","XPDIK",141,0)
+ N DA,DIC,DIOVRD,OLDA,EPOS,EPRE,FPOS,FPRE,ORD,XREF,XPDQUIT
+"RTN","XPDIK",142,0)
+ S DIC=%1,DA=%2,OLDA=%3
+"RTN","XPDIK",143,0)
+ ;check that % is callable
+"RTN","XPDIK",144,0)
+ D  I %5="" Q 0
+"RTN","XPDIK",145,0)
+ . S:%5="" %5=$P(%4,"("),%4="",%="^"_%  ; no tag
+"RTN","XPDIK",146,0)
+ . I %4]"" S:$T(@%4^@%5)="" %5="" Q  ;tag^routine don't exists
+"RTN","XPDIK",147,0)
+ . S:$T(^@%5)="" %5="" ;routine don't exists
+"RTN","XPDIK",148,0)
+ . Q
+"RTN","XPDIK",149,0)
+ ;XPDQUIT=quit this level of processing
+"RTN","XPDIK",150,0)
+ D @% Q $D(XPDQUIT)
+"RTN","XPDIK",151,0)
+ Q
+"RTN","XPDIK",152,0)
+ ;
+"RTN","XPDIK",153,0)
+XPCOM(XPDF,XPDJ) ;complete checkpoint for file XPDF
+"RTN","XPDIK",154,0)
+ ;XPDJ=1 only for data of fm files, it set the field to edit = 2
+"RTN","XPDIK",155,0)
+ N XPD,%,Z
+"RTN","XPDIK",156,0)
+ S %=$$NOW^XLFDT,Z=$S(XPDCP="KRN":9.715,1:9.714),XPD(Z,XPDF_","_XPDA_",",$G(XPDJ)+1)=%
+"RTN","XPDIK",157,0)
+ ;if Build Components, save the ORDer number
+"RTN","XPDIK",158,0)
+ S:Z=9.715 XPD(Z,XPDF_","_XPDA_",",2)=ORD
+"RTN","XPDIK",159,0)
+ D FILE^DIE("","XPD")
+"RTN","XPDIK",160,0)
+ Q 1
+"RTN","XPDIK",161,0)
+ ;
+"RTN","XPDIK",162,0)
+XPCK(XPDI) ;setup check points for file type XPDI
+"RTN","XPDIK",163,0)
+ ;XPDI="KRN"-components, ="FIA"-files
+"RTN","XPDIK",164,0)
+ N %,XPD,XPDF,XPDJ,XPDK
+"RTN","XPDIK",165,0)
+ ;XPDK=sub DD
+"RTN","XPDIK",166,0)
+ S XPDK=$S(XPDI="KRN":9.715,1:9.714),XPDF=0
+"RTN","XPDIK",167,0)
+ F %=1:1 S XPDF=$O(^XTMP("XPDI",XPDA,XPDI,XPDF)) Q:'XPDF  S (XPDJ(%),XPD(XPDK,"+"_%_","_XPDA_",",.01))=XPDF
+"RTN","XPDIK",168,0)
+ D:$D(XPD)>9 UPDATE^DIE("","XPD","XPDJ")
+"RTN","XPDIK",169,0)
+ Q
+"RTN","XPDIL")
+0^14^B21561860^B21320112
+"RTN","XPDIL",1,0)
+XPDIL ;SFISC/RSD - load Distribution Global ;05/05/2008
+"RTN","XPDIL",2,0)
+ ;;8.0;KERNEL;**15,44,58,68,108,422,525,672**;Jul 10, 1995;Build 28
+"RTN","XPDIL",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XPDIL",4,0)
+ ;
+"RTN","XPDIL",5,0)
+EN1 N POP,XPDA,XPDST,XPDIT,XPDT,XPDGP,XPDQUIT,XPDREQAB,XPDSKPE
+"RTN","XPDIL",6,0)
+ S:'$D(DT) DT=$$DT^XLFDT S:'$D(U) U="^"
+"RTN","XPDIL",7,0)
+ S XPDST=0
+"RTN","XPDIL",8,0)
+ D ST I $G(XPDQUIT) D ABRTALL^XPDI(1) G NONE
+"RTN","XPDIL",9,0)
+ ;XPDST= starting Build
+"RTN","XPDIL",10,0)
+ ;XPDT("DA",ien)=seq # to install
+"RTN","XPDIL",11,0)
+ ;XPDT("NM",build name)=seq #
+"RTN","XPDIL",12,0)
+ ;XPDT(seq #)=ien^Build name
+"RTN","XPDIL",13,0)
+ ;XPDT("GP",global)= 1-replace, 0-overwrite^ien
+"RTN","XPDIL",14,0)
+ ;XPDGP=globals from a Global Package
+"RTN","XPDIL",15,0)
+ ;XPDSKPE=1 don't run Environment Check^has question been asked
+"RTN","XPDIL",16,0)
+ S XPDIT=0,XPDSKPE="0^0"
+"RTN","XPDIL",17,0)
+ F  S XPDIT=$O(XPDT(XPDIT)) Q:'XPDIT  S XPDA=+XPDT(XPDIT) D  I '$D(XPDT) Q
+"RTN","XPDIL",18,0)
+ .;check if this Build has an Envir. Check
+"RTN","XPDIL",19,0)
+ .I $G(^XTMP("XPDI",XPDA,"PRE"))]"" D  I $G(XPDQUIT) D ABRTALL^XPDI(1) Q
+"RTN","XPDIL",20,0)
+ ..;quit if we already asked this question
+"RTN","XPDIL",21,0)
+ ..Q:$P(XPDSKPE,U,2)
+"RTN","XPDIL",22,0)
+ ..S $P(XPDSKPE,U,2)=1
+"RTN","XPDIL",23,0)
+ ..N DIR,DIRUT
+"RTN","XPDIL",24,0)
+ ..S DIR(0)="Y",DIR("A")="Want to RUN the Environment Check Routine",DIR("B")="YES"
+"RTN","XPDIL",25,0)
+ ..S DIR("A",1)="Build "_$P(XPDT(XPDIT),U,2)_" has an Environmental Check Routine"
+"RTN","XPDIL",26,0)
+ ..D ^DIR I $D(DIRUT) S XPDQUIT=1 Q
+"RTN","XPDIL",27,0)
+ ..S:'Y XPDSKPE="1^1"
+"RTN","XPDIL",28,0)
+ .D PKG^XPDIL1(XPDA)
+"RTN","XPDIL",29,0)
+ ;Global Package
+"RTN","XPDIL",30,0)
+ G:$D(XPDGP) ^XPDIGP
+"RTN","XPDIL",31,0)
+ I $D(XPDT),$D(^XPD(9.7,+XPDST,0)) W !,"Use INSTALL NAME: ",$P(^(0),U)," to install this Distribution.",!
+"RTN","XPDIL",32,0)
+ Q
+"RTN","XPDIL",33,0)
+ST ;global input
+"RTN","XPDIL",34,0)
+ N DIR,DIRUT,GR,IOP,X,Y,Z,%ZIS
+"RTN","XPDIL",35,0)
+ G:'$D(^DD(3.5,0)) OPEN
+"RTN","XPDIL",36,0)
+ I '$D(^%ZIS(1,"B","HFS")) W !!,"You must have a device called 'HFS' in order to load a distribution!",*7 S XPDQUIT=1 Q
+"RTN","XPDIL",37,0)
+ D HOME^%ZIS
+"RTN","XPDIL",38,0)
+ S DIR(0)="F^3:245",DIR("A")="Enter a Host File",DIR("?")="Enter a filename and/or path to input Distribution."
+"RTN","XPDIL",39,0)
+ D ^DIR I $D(DIRUT) S XPDQUIT=1 Q
+"RTN","XPDIL",40,0)
+ S %ZIS="",%ZIS("HFSNAME")=Y,%ZIS("HFSMODE")="R",IOP="HFS"
+"RTN","XPDIL",41,0)
+ D ^%ZIS I POP W !,"Couldn't open file or HFS device!!",*7 S XPDQUIT=1 Q
+"RTN","XPDIL",42,0)
+ ;don't close device if we have a global package, we need to bring in the globals now
+"RTN","XPDIL",43,0)
+ D GI,^%ZISC:'$D(XPDGP)!$G(XPDQUIT)
+"RTN","XPDIL",44,0)
+ Q
+"RTN","XPDIL",45,0)
+ ;
+"RTN","XPDIL",46,0)
+ ;if no device file, Virgin Install
+"RTN","XPDIL",47,0)
+OPEN ;use open command
+"RTN","XPDIL",48,0)
+ N IO,IOPAR,DIR,DIRUT,DTOUT,DUOUT
+"RTN","XPDIL",49,0)
+ S DIR(0)="F^1:79",DIR("A")="Device Name"
+"RTN","XPDIL",50,0)
+ S DIR("?",1)="Device Name is either the name of the HFS file or the name of the HFS Device.",DIR("?",2)="i.e.  for MSM enter  51",DIR("?")="      for DSM enter  DISK$USER::[ANONYMOUS]:KRN8.KID"
+"RTN","XPDIL",51,0)
+ D ^DIR I $D(DIRUT) S POP=1 Q
+"RTN","XPDIL",52,0)
+ S IO=Y,DIR(0)="FO^1:79",DIR("A")="Device Parameters"
+"RTN","XPDIL",53,0)
+ S DIR("?",1)="Device Parameter is the Open parameter this M operating system needs to",DIR("?",2)="open the Device Name.",DIR("?",3)="i.e. for MSM enter  (""B:\KRN8.KID"":""R"")",DIR("?")="     for DSM enter  READONLY"
+"RTN","XPDIL",54,0)
+ D ^DIR I $D(DTOUT)!$D(DUOUT) S POP=1 Q
+"RTN","XPDIL",55,0)
+ S IOPAR=Y
+"RTN","XPDIL",56,0)
+ X "O IO:"_IOPAR_":10" E  U $P W !,"Couldn't open ",IO S POP=1 Q
+"RTN","XPDIL",57,0)
+ S IO(0)=$P
+"RTN","XPDIL",58,0)
+ D GI D ^%ZISC
+"RTN","XPDIL",59,0)
+ Q
+"RTN","XPDIL",60,0)
+ ;
+"RTN","XPDIL",61,0)
+GI N X,XPDSEQ,Y,Z
+"RTN","XPDIL",62,0)
+ U IO R X:10,Y:10 ;rwf was :0
+"RTN","XPDIL",63,0)
+ U IO(0) W !!,X,!,"Comment: ",Y
+"RTN","XPDIL",64,0)
+ S XPDST("H")=Y,XPDST("H1")=Y_"  ;Created on "_$P(X,"KIDS Distribution saved on ",2)
+"RTN","XPDIL",65,0)
+ ;Z is the string of Builds in this file
+"RTN","XPDIL",66,0)
+ U IO F X=1:1 R Z:1 S Z=$P(Z,"**KIDS**",2,99) Q:Z=""  S X(X)=Z
+"RTN","XPDIL",67,0)
+ U IO(0) I $G(X(1))="" W !!,"This is not a Distribution HFS File!" S XPDQUIT=1 Q
+"RTN","XPDIL",68,0)
+ ;global package, set XPDGP=flag;global^flag;global^...  flag=1 replace
+"RTN","XPDIL",69,0)
+ I $P(X(1),":")="GLOBALS" S XPDGP=$P(X(1),U,2,99),X(1)=$P(X(1),U)
+"RTN","XPDIL",70,0)
+ S XPDIT=0,X(1)=$P(X(1),":",2,99)
+"RTN","XPDIL",71,0)
+ W !!,"This Distribution contains Transport Globals for the following Package(s):"
+"RTN","XPDIL",72,0)
+ F X=1:1:X-1 F Z=1:1 S Y=$P(X(X),U,Z) Q:Y=""  D  Q:$G(XPDQUIT)
+"RTN","XPDIL",73,0)
+ . ;can't install if global exist, that means Build never finish install
+"RTN","XPDIL",74,0)
+ . ;INST will show name
+"RTN","XPDIL",75,0)
+ . S XPDIT=XPDIT+1 I '$$INST^XPDIL1(Y) S XPDQUIT=1 Q
+"RTN","XPDIL",76,0)
+ Q:$G(XPDQUIT)
+"RTN","XPDIL",77,0)
+ W !,"Distribution OK!",!
+"RTN","XPDIL",78,0)
+ D:$D(XPDGP) DISP^XPDIGP
+"RTN","XPDIL",79,0)
+ S DIR(0)="Y",DIR("A")="Want to Continue with Load",DIR("B")="YES"
+"RTN","XPDIL",80,0)
+ D ^DIR I $D(DIRUT)!'Y S XPDQUIT=1 Q
+"RTN","XPDIL",81,0)
+ W !,"Loading Distribution...",!
+"RTN","XPDIL",82,0)
+ ;reset expiration date to T+7 on transport global
+"RTN","XPDIL",83,0)
+ S ^XTMP("XPDI",0)=$$FMADD^XLFDT(DT,7)_U_DT
+"RTN","XPDIL",84,0)
+ ;start reading the HFS again
+"RTN","XPDIL",85,0)
+ U IO R X:10,Y:10 ;rwf was :0
+"RTN","XPDIL",86,0)
+ ;the next read must be the INSTALL NAME
+"RTN","XPDIL",87,0)
+ I X'="**INSTALL NAME**"!'$D(XPDT("NM",Y)) U IO(0) W !!,"ERROR in HFS file format!" S XPDQUIT=1 Q
+"RTN","XPDIL",88,0)
+ ;XPDSEQ is the disk sequence number
+"RTN","XPDIL",89,0)
+ S %=XPDT("NM",Y),GR="^XTMP(""XPDI"","_+XPDT(%)_",",XPDSEQ=1
+"RTN","XPDIL",90,0)
+ ;X=global ref, Y=global value. DIRUT is when user aborts
+"RTN","XPDIL",91,0)
+ ;rwf next line was :0
+"RTN","XPDIL",92,0)
+ F  R X:10,Y:10 Q:X="**END**"  D  I $D(DIRUT) S XPDQUIT=1 Q
+"RTN","XPDIL",93,0)
+ .I X="**INSTALL NAME**" D  Q
+"RTN","XPDIL",94,0)
+ ..S %=+$G(XPDT("NM",Y)) I '% S DIRUT=1 Q
+"RTN","XPDIL",95,0)
+ ..S GR="^XTMP(""XPDI"","_+XPDT(%)_","
+"RTN","XPDIL",96,0)
+ .S @(GR_X)=Y
+"RTN","XPDIL",97,0)
+ U IO(0)
+"RTN","XPDIL",98,0)
+ Q
+"RTN","XPDIL",99,0)
+ ;
+"RTN","XPDIL",100,0)
+NONE W !!,"**NOTHING LOADED**",!
+"RTN","XPDIL",101,0)
+ Q
+"RTN","XPDIP")
+0^6^B36820171^B41486911
+"RTN","XPDIP",1,0)
+XPDIP ;SFISC/RSD - Install Package & Routine file ;03/08/2006
+"RTN","XPDIP",2,0)
+ ;;8.0;KERNEL;**15,21,28,30,41,44,51,58,83,92,100,108,137,229,350,393,517,672**;Jul 10, 1995;Build 28
+"RTN","XPDIP",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XPDIP",4,0)
+ Q
+"RTN","XPDIP",5,0)
+PKG ;
+"RTN","XPDIP",6,0)
+ N %,OLDA,DA,DIK,XPD,XPDFIL,XPDPKG,XPDBLDA,Y
+"RTN","XPDIP",7,0)
+ ;update variable for graphic display
+"RTN","XPDIP",8,0)
+ I $D(XPDIDVT) S XPDIDTOT=10,XPDIDMOD=1,XPDIDCNT=0 D:XPDIDVT UPDATE^XPDID(0)
+"RTN","XPDIP",9,0)
+ ;XPDPKG=ien of Package file, OLDA=old Package ien
+"RTN","XPDIP",10,0)
+ S Y=$$PKGADD,XPDPKG=$P(Y,U),OLDA=$P(Y,U,2)
+"RTN","XPDIP",11,0)
+ ;Package file entry not sent, XPDPKG=0
+"RTN","XPDIP",12,0)
+ G:'XPDPKG PKGEND
+"RTN","XPDIP",13,0)
+ ;update version multiple
+"RTN","XPDIP",14,0)
+ S DA=XPDPKG D PKGV
+"RTN","XPDIP",15,0)
+PKGH I $D(XPDIDVT) S XPDIDCNT=XPDIDCNT+2 D UPDATE^XPDID(XPDIDCNT)
+"RTN","XPDIP",16,0)
+ S %=$P(^DIC(9.4,XPDPKG,0),U,4)
+"RTN","XPDIP",17,0)
+ ;repoint Help Frame (0;4)
+"RTN","XPDIP",18,0)
+ I $L(%),'% S $P(^DIC(9.4,XPDPKG,0),U,4)=$$LK^XPDIA("^DIC(9.2)",%),DIK="^DIC(9.4," D IX1^DIK
+"RTN","XPDIP",19,0)
+PKGEND S XPDBLDA=$$BLD(XPDBLD) Q:'XPDBLDA
+"RTN","XPDIP",20,0)
+ ;Move the Test/SEQ number from build to Install file.
+"RTN","XPDIP",21,0)
+ S ^XPD(9.7,XPDA,6)=$G(^XPD(9.6,XPDBLDA,6))
+"RTN","XPDIP",22,0)
+ ;move Alpha/Beta testing info to Kernel site para file
+"RTN","XPDIP",23,0)
+ I XPDPKG S %=$G(^XPD(9.6,XPDBLDA,"ABPKG")) D
+"RTN","XPDIP",24,0)
+ .;Install message and they have an address, set flag in XPDIST
+"RTN","XPDIP",25,0)
+ .I $P(%,U)="y",$P(%,U,2)="y",$L($P(%,U,3)) S $P(XPDIST,U,2)=$P(%,U,3)
+"RTN","XPDIP",26,0)
+ .D EN^XQABLOAD(XPDBLDA)
+"RTN","XPDIP",27,0)
+ Q
+"RTN","XPDIP",28,0)
+PKGADD() ;check Package file, add if not there
+"RTN","XPDIP",29,0)
+ ;return new Package file ien^old ien
+"RTN","XPDIP",30,0)
+ N DA,DIK,XPD,XPDFIL,XPDO,X,Y
+"RTN","XPDIP",31,0)
+ S DA=+$P(^XPD(9.7,XPDA,0),U,2),XPDO=+$O(^XTMP("XPDI",XPDA,"PKG",0)),OLDA(0)=$G(^(XPDO,0)),X=$P(OLDA(0),U),XPDDR(1)="$P(OLDA(0),U,2)"
+"RTN","XPDIP",32,0)
+ I DA,$D(^DIC(9.4,DA,0)) Q DA_U_XPDO
+"RTN","XPDIP",33,0)
+ ;quit if there was no package entry sent
+"RTN","XPDIP",34,0)
+ Q:'XPDO "0^0"
+"RTN","XPDIP",35,0)
+ S XPDFIL=9.4,Y=$$DIC^XPDIK(9.4,X,,,.XPDDR) Q:'Y "0^0"
+"RTN","XPDIP",36,0)
+ S DA=+Y
+"RTN","XPDIP",37,0)
+ ;if new entry in package file, bring in everything
+"RTN","XPDIP",38,0)
+ I $P(Y,U,3) D
+"RTN","XPDIP",39,0)
+ .M ^DIC(9.4,DA)=^XTMP("XPDI",XPDA,"PKG",XPDO)
+"RTN","XPDIP",40,0)
+ .;kill the -1 flag node first
+"RTN","XPDIP",41,0)
+ .K ^DIC(9.4,DA,-1)
+"RTN","XPDIP",42,0)
+ .;re-cross ref after adding a new package
+"RTN","XPDIP",43,0)
+ .S DIK="^DIC(9.4," D IX1^DIK
+"RTN","XPDIP",44,0)
+ ;add package to file 9.7
+"RTN","XPDIP",45,0)
+ S XPD(9.7,XPDA_",",1)=DA D FILE^DIE("","XPD")
+"RTN","XPDIP",46,0)
+ Q DA_U_XPDO
+"RTN","XPDIP",47,0)
+ ;
+"RTN","XPDIP",48,0)
+BLD(XPDBLD) ;add Build entry, XPDBLD=Build ien in ^XTMP("XPDI",XPDA,"BLD",
+"RTN","XPDIP",49,0)
+ N %,DA,DIK,XPDFIL,Y
+"RTN","XPDIP",50,0)
+ I $D(XPDIDVT) S XPDIDCNT=XPDIDCNT+4 D UPDATE^XPDID(XPDIDCNT)
+"RTN","XPDIP",51,0)
+ ;XPDBLD=Build ien in ^XTMP, set in XPDIJ
+"RTN","XPDIP",52,0)
+ S XPDFIL=9.6,Y=$$DIC^XPDIK(9.6,XPDNM) Q:'Y ""
+"RTN","XPDIP",53,0)
+ S DA=+Y
+"RTN","XPDIP",54,0)
+ ;Build entry not new, remove old data
+"RTN","XPDIP",55,0)
+ I '$P(Y,U,3) S %=$P(^XPD(9.6,DA,0),U,2) K ^XPD(9.6,DA) K:% ^XPD(9.6,"C",%,DA)
+"RTN","XPDIP",56,0)
+ M ^XPD(9.6,DA)=^XTMP("XPDI",XPDA,"BLD",XPDBLD)
+"RTN","XPDIP",57,0)
+ ;reset Package File Link (0;2)
+"RTN","XPDIP",58,0)
+ ;XPDIST = national site tracking^A/B install message address
+"RTN","XPDIP",59,0)
+ S $P(^XPD(9.6,DA,0),U,2)=$S(XPDPKG:XPDPKG,1:"") S:$P(^(0),U,5)="y" XPDIST=1
+"RTN","XPDIP",60,0)
+ ;re-index cross-ref. on fields .01 and 1
+"RTN","XPDIP",61,0)
+ S DIK="^XPD(9.6," F Y=.01,1 S DIK(1)=Y D EN1^DIK
+"RTN","XPDIP",62,0)
+ I $D(XPDIDVT) D UPDATE^XPDID(XPDIDTOT)
+"RTN","XPDIP",63,0)
+ Q DA
+"RTN","XPDIP",64,0)
+ ;
+"RTN","XPDIP",65,0)
+ ;update the version multiple in the package file
+"RTN","XPDIP",66,0)
+PKGV N %
+"RTN","XPDIP",67,0)
+ I $D(XPDIDVT) S XPDIDCNT=XPDIDCNT+2 D UPDATE^XPDID(XPDIDCNT)
+"RTN","XPDIP",68,0)
+ ;%=ien in the Version multiple_U_ien in Patch multiple in ^XTMP
+"RTN","XPDIP",69,0)
+ S %=$G(^XTMP("XPDI",XPDA,"PKG",OLDA,-1))
+"RTN","XPDIP",70,0)
+ I XPDNM'["*" D  Q
+"RTN","XPDIP",71,0)
+ .S %=+% Q:'$D(^XTMP("XPDI",XPDA,"PKG",OLDA,22,%,0))  S %=^(0) S:$D(^(1)) %(1)=$NA(^(1))
+"RTN","XPDIP",72,0)
+ .S $P(%,U,3,4)=DT_U_DUZ,%=$$PKGVER(DA,.%)
+"RTN","XPDIP",73,0)
+ ;update patch history multiple
+"RTN","XPDIP",74,0)
+ Q:'$D(^XTMP("XPDI",XPDA,"PKG",OLDA,22,+%,"PAH",+$P(%,U,2),0))  S %=$P(^(0),U) S:$D(^(1)) %(1)=$NA(^(1))
+"RTN","XPDIP",75,0)
+ ;check File Comment, %=patch number
+"RTN","XPDIP",76,0)
+ S:^XPD(9.7,XPDA,2)[" SEQ #" %=$P(^(2),"*",3)
+"RTN","XPDIP",77,0)
+ S $P(%,U,2,3)=$$NOW^XLFDT()_U_DUZ,%=$$PKGPAT(DA,$$VER^XPDUTL(XPDNM),.%)
+"RTN","XPDIP",78,0)
+ Q
+"RTN","XPDIP",79,0)
+ ;
+"RTN","XPDIP",80,0)
+PKGVER(XPDPDA,XPDI) ;update version in package file, XPDPDA=Package file ien, return ien of version multiple
+"RTN","XPDIP",81,0)
+ ;XPDI=version^date distr.^date installed^install by
+"RTN","XPDIP",82,0)
+ ;XPDI(1)=root of description field
+"RTN","XPDIP",83,0)
+ N I,X,XPD,XPDIEN,XPDJ,XPDV
+"RTN","XPDIP",84,0)
+ S XPDIEN=","_XPDPDA_",",XPDV=$$MDIC(9.49,XPDIEN,$P(XPDI,U)) Q:'XPDV 0
+"RTN","XPDIP",85,0)
+ S XPD(9.4,XPDPDA_",",13)=$P(XPDI,U),X="XPD(9.49,"""_XPDV_XPDIEN_""")"
+"RTN","XPDIP",86,0)
+ F I=1:1:3 S:$P(XPDI,U,I+1)]"" @X@(I)=$P(XPDI,U,I+1)
+"RTN","XPDIP",87,0)
+ S:$D(XPDI(1)) @X@(41)=XPDI(1)
+"RTN","XPDIP",88,0)
+ D FILE^DIE("","XPD")
+"RTN","XPDIP",89,0)
+ Q XPDV
+"RTN","XPDIP",90,0)
+ ;
+"RTN","XPDIP",91,0)
+PKGPAT(XPDPDA,XPDV,XPDI) ;update patch history
+"RTN","XPDIP",92,0)
+ ;INPUT: XPDPDA=Package file ien, XPDV=version
+"RTN","XPDIP",93,0)
+ ;XPDI=patch^date installed^install by
+"RTN","XPDIP",94,0)
+ ;RETURNS: version ien^patch ien^[CURRENT VERSION, if it was set]
+"RTN","XPDIP",95,0)
+ N I,X,XPD,XPDP,XPDIEN,CURVER
+"RTN","XPDIP",96,0)
+ ;quit if we can't find the version multiple, resets XPDV=ien of version
+"RTN","XPDIP",97,0)
+ S XPDIEN=","_XPDPDA_",",XPDV=$$MDIC(9.49,XPDIEN,XPDV) Q:'XPDV 0
+"RTN","XPDIP",98,0)
+ S XPDIEN=","_XPDV_XPDIEN,XPDP=$$MDIC(9.4901,XPDIEN,$P(XPDI,U)) Q:'XPDP 0
+"RTN","XPDIP",99,0)
+ S X="XPD(9.4901,"""_XPDP_XPDIEN_""")"
+"RTN","XPDIP",100,0)
+ F I=.02,.03 S:$P(XPDI,U,I*100)]"" @X@(I)=$P(XPDI,U,I*100)
+"RTN","XPDIP",101,0)
+ S:$D(XPDI(1)) @X@(1)=XPDI(1)
+"RTN","XPDIP",102,0)
+ ;if no CURRENT VERSION, set it
+"RTN","XPDIP",103,0)
+ I $G(^DIC(9.4,XPDPDA,"VERSION"))="" S XPD(9.4,XPDPDA_",",13)=XPDV,CURVER=XPDV
+"RTN","XPDIP",104,0)
+ D FILE^DIE("","XPD")
+"RTN","XPDIP",105,0)
+ Q XPDV_U_XPDP_U_$G(CURVER)
+"RTN","XPDIP",106,0)
+ ;
+"RTN","XPDIP",107,0)
+ ;XPDF=subfile #,XPDIEN=ien string, X=input
+"RTN","XPDIP",108,0)
+MDIC(XPDF,XPDIEN,XPDX) ;
+"RTN","XPDIP",109,0)
+ N DIERR,XPD,XPDN
+"RTN","XPDIP",110,0)
+ D FIND^DIC(XPDF,XPDIEN,"","XQf",XPDX,5,"","","","XPD")
+"RTN","XPDIP",111,0)
+ ;one or more matches, just return first one
+"RTN","XPDIP",112,0)
+ I $G(XPD(0)) D:XPD(0)>1  Q XPD(1)
+"RTN","XPDIP",113,0)
+ .N %
+"RTN","XPDIP",114,0)
+ .S %(1)=$P(^DD(XPDF,.01,0),U)_"  "_XPDX_"  is Duplicated,",%(2)=" only ien #"_XPD(1)_" was updated."
+"RTN","XPDIP",115,0)
+ .D MES^XPDUTL(.%)
+"RTN","XPDIP",116,0)
+ ;add a new entry
+"RTN","XPDIP",117,0)
+ S XPDN(XPDF,"+1"_XPDIEN,.01)=XPDX K XPD
+"RTN","XPDIP",118,0)
+ D UPDATE^DIE("","XPDN","XPD")
+"RTN","XPDIP",119,0)
+ I '$G(XPD(1)) D BMES^XPDUTL(" "_$P(^DD(XPDF,.01,0),U)_" "_XPDX_" **Couldn't Add to file**") Q 0
+"RTN","XPDIP",120,0)
+ Q XPD(1)
+"RTN","XPDIP",121,0)
+ ;
+"RTN","XPDIP",122,0)
+RTN ;move rtns to install file
+"RTN","XPDIP",123,0)
+ N XPD,XPDC,XPDCR,XPDI,XPDJ,XPDK,XPDL,XPDM,XPDR,XPDRH,X,NOW
+"RTN","XPDIP",124,0)
+ K ^XPD(9.7,XPDA,"RTN"),^TMP($J)
+"RTN","XPDIP",125,0)
+ S (XPDC,XPDCR,XPDRH)=0,XPDJ="",NOW=$$NOW^XLFDT()
+"RTN","XPDIP",126,0)
+ ;get all routines that were loaded, XPDM=action
+"RTN","XPDIP",127,0)
+ ;actions are 0=load, 1=delete, 2=skip
+"RTN","XPDIP",128,0)
+ F  S XPDJ=$O(^XTMP("XPDI",XPDA,"RTN",XPDJ)) Q:XPDJ=""  S XPDM=^(XPDJ) D:'XPDM
+"RTN","XPDIP",129,0)
+ .;XPD, build array to update ROUTINE multiple in INSTALL file
+"RTN","XPDIP",130,0)
+ .S XPDC=XPDC+1,^TMP($J,"XPDL",XPDC)=XPDC,^TMP($J,"XPD",9.704,"+"_XPDC_","_XPDA_",",.01)=XPDJ
+"RTN","XPDIP",131,0)
+ .;XPDR, build array to update ROUTINE file, Set install date
+"RTN","XPDIP",132,0)
+ .;S:'$D(^DIC(9.8,"B",XPDJ)) XPDCR=XPDCR+1,^TMP($J,"XPDR",9.8,"?+"_XPDCR_",",.01)=XPDJ,^(1)="R"
+"RTN","XPDIP",133,0)
+ .S XPDCR=XPDCR+1,^TMP($J,"XPDR",9.8,"?+"_XPDCR_",",.01)=XPDJ,^(1)="R",^(7.4)=NOW ;**229
+"RTN","XPDIP",134,0)
+ ;if we are doing VT graphic display, update only 40%
+"RTN","XPDIP",135,0)
+ I $D(XPDIDVT) S XPDIDCNT=XPDIDTOT*.4 D UPDATE^XPDID(XPDIDCNT)
+"RTN","XPDIP",136,0)
+ F XPDK="DIKZ","DIEZ","DIPZ" D
+"RTN","XPDIP",137,0)
+ .S XPDI=0
+"RTN","XPDIP",138,0)
+ .;loop thru list of compile template routines
+"RTN","XPDIP",139,0)
+ .;XTMP("XPDI",XPDA,"DIKZ",ien,routine name)
+"RTN","XPDIP",140,0)
+ .F  S XPDI=$O(^XTMP("XPDI",XPDA,XPDK,XPDI)),XPDJ="" Q:'XPDI  D
+"RTN","XPDIP",141,0)
+ ..I 'XPDRH D BMES^XPDUTL(" The following Routines were created during this install:") S XPDRH=1
+"RTN","XPDIP",142,0)
+ ..F  S XPDJ=$O(^XTMP("XPDI",XPDA,XPDK,XPDI,XPDJ)) Q:XPDJ=""  D:'$D(^XTMP("XPDI",XPDA,"RTN",XPDJ))
+"RTN","XPDIP",143,0)
+ ...S XPDC=XPDC+1,^TMP($J,"XPDL",XPDC)=XPDC,^TMP($J,"XPD",9.704,"+"_XPDC_","_XPDA_",",.01)=XPDJ
+"RTN","XPDIP",144,0)
+ ...D MES^XPDUTL("     "_XPDJ)
+"RTN","XPDIP",145,0)
+ ;update routine multiple in Install file with routines and
+"RTN","XPDIP",146,0)
+ ;compile template routines
+"RTN","XPDIP",147,0)
+ I $D(^TMP($J,"XPD"))>9 D
+"RTN","XPDIP",148,0)
+ .D UPDATE^DIE("","^TMP($J,""XPD"")","^TMP($J,""XPDL"")")
+"RTN","XPDIP",149,0)
+ .;if we are doing VT graphic display, update only 40%
+"RTN","XPDIP",150,0)
+ .I $D(XPDIDVT) S XPDIDCNT=XPDIDCNT+(XPDIDTOT*.40) D UPDATE^XPDID(XPDIDCNT)
+"RTN","XPDIP",151,0)
+ ;update Routine file
+"RTN","XPDIP",152,0)
+ D:$D(^TMP($J,"XPDR"))>9 UPDATE^DIE("","^TMP($J,""XPDR"")")
+"RTN","XPDIP",153,0)
+ ;if we are doing VT graphic display, update 100%
+"RTN","XPDIP",154,0)
+ I $D(XPDIDVT) D UPDATE^XPDID(XPDIDTOT)
+"RTN","XPDIP",155,0)
+ Q
+"RTN","XPDIST")
+0^5^B18736775^B18641684
+"RTN","XPDIST",1,0)
+XPDIST ;SFISC/RSD - site tracking ;03/05/2008
+"RTN","XPDIST",2,0)
+ ;;8.0;KERNEL;**66,108,185,233,350,393,486,539,547,672**;Jul 10, 1995;Build 28
+"RTN","XPDIST",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XPDIST",4,0)
+ ;Returns ""=failed, XMZ=sent
+"RTN","XPDIST",5,0)
+ ;D0=ien in file 9.7, XPY=national site tracking^address(optional)
+"RTN","XPDIST",6,0)
+EN(D0,XPY) ;EF. send message
+"RTN","XPDIST",7,0)
+ N %,DIFROM,XPD,XPD0,XPD1,XPD2,XPDV,XPZ,X,X1,Z,Y,XPD6,XPDTRACK
+"RTN","XPDIST",8,0)
+ ;Get data needed
+"RTN","XPDIST",9,0)
+ I '$D(^XPD(9.7,$G(D0),0)) D BMES^XPDUTL(" INSTALL file entry missing") Q ""
+"RTN","XPDIST",10,0)
+ ;p350 -add node 6 for the Test# and Seq#. -REM
+"RTN","XPDIST",11,0)
+ S XPD0=^XPD(9.7,D0,0),XPD1=$G(^(1)),XPD2=$G(^(2)),XPD6=$G(^(6))
+"RTN","XPDIST",12,0)
+ I '$P(XPD0,U,2) D BMES^XPDUTL(" No link to PACKAGE file") Q ""
+"RTN","XPDIST",13,0)
+ S XPD=$P($G(^DIC(9.4,+$P(XPD0,U,2),0)),U),XPDV=$$VER^XPDUTL($P(XPD0,U))
+"RTN","XPDIST",14,0)
+ I XPD="" D BMES^XPDUTL(" PACKAGE file entry missing") Q ""
+"RTN","XPDIST",15,0)
+ ;XPZ(1)=start, XPZ(2)=completion date/time, XPZ(3)=run time
+"RTN","XPDIST",16,0)
+ S XPZ(1)=$P(XPD1,U),XPZ(2)=$P(XPD1,U,3),XPZ(3)=$$FMDIFF^XLFDT(XPZ(2),XPZ(1),3),XPZ(1)=$$FMTE^XLFDT(XPZ(1)),XPZ(2)=$$FMTE^XLFDT(XPZ(2))
+"RTN","XPDIST",17,0)
+ D LOCAL
+"RTN","XPDIST",18,0)
+ S XPDTRACK=$$TRACK
+"RTN","XPDIST",19,0)
+ D REMEDY ;p350 -REM
+"RTN","XPDIST",20,0)
+ Q $$FORUM()
+"RTN","XPDIST",21,0)
+LOCAL ;Send a message to local mail group
+"RTN","XPDIST",22,0)
+ N XMY,XPDTEXT,XMTEXT,XMDUZ,XMSUB,XMZ,XMMG
+"RTN","XPDIST",23,0)
+ K ^TMP($J)
+"RTN","XPDIST",24,0)
+ S X=$$MAILGRP^XPDUTL(XPD) Q:X=""
+"RTN","XPDIST",25,0)
+ S XMY(X)="" D GETENV^%ZOSV
+"RTN","XPDIST",26,0)
+ ;Message for users
+"RTN","XPDIST",27,0)
+ S XPDTEXT(1,0)="PACKAGE INSTALL"
+"RTN","XPDIST",28,0)
+ S XPDTEXT(2,0)="SITE: "_$G(^XMB("NETNAME"))
+"RTN","XPDIST",29,0)
+ S XPDTEXT(3,0)="PACKAGE: "_XPD
+"RTN","XPDIST",30,0)
+ S XPDTEXT(4,0)="VERSION: "_XPDV
+"RTN","XPDIST",31,0)
+ S XPDTEXT(5,0)="Start time: "_XPZ(1)
+"RTN","XPDIST",32,0)
+ S XPDTEXT(6,0)="Completion time: "_XPZ(2)
+"RTN","XPDIST",33,0)
+ S XPDTEXT(7,0)="Environment: "_Y
+"RTN","XPDIST",34,0)
+ S XPDTEXT(8,0)="Installed by: "_$P($G(^VA(200,+$P(XPD0,U,11),0)),U)
+"RTN","XPDIST",35,0)
+ S XPDTEXT(9,0)="Install Name: "_$P(XPD0,U)
+"RTN","XPDIST",36,0)
+ S XPDTEXT(10,0)="Distribution Date: "_$$FMTE^XLFDT($P(XPD1,U,4))
+"RTN","XPDIST",37,0)
+ S XMDUZ=$S($P(XPD0,U,11):+$P(XPD0,U,11),1:.5),XMTEXT="XPDTEXT(",XMSUB=$P(XPD0,U)_" INSTALLATION"
+"RTN","XPDIST",38,0)
+ D ^XMD
+"RTN","XPDIST",39,0)
+ Q
+"RTN","XPDIST",40,0)
+TRACK() ;EF. Should VA track the installation of this patch at a national level?
+"RTN","XPDIST",41,0)
+ Q:$G(XPY)="" 0  ; No - National site tracking was not requested
+"RTN","XPDIST",42,0)
+ ;Quit if not VA production primary domain
+"RTN","XPDIST",43,0)
+ I $G(^XMB("NETNAME"))'[".DOMAIN.EXT" D BMES^XPDUTL(" Not a VA primary domain") Q 0
+"RTN","XPDIST",44,0)
+ ;X ^%ZOSF("UCI") S %=^%ZOSF("PROD")
+"RTN","XPDIST",45,0)
+ ;S:%'["," Y=$P(Y,",")
+"RTN","XPDIST",46,0)
+ ;I Y'=% D BMES^XPDUTL(" Not a production UCI") Q ""
+"RTN","XPDIST",47,0)
+ ; 486/GMB Replaced the above 3 lines with the following line:
+"RTN","XPDIST",48,0)
+ I '$$PROD^XUPROD D BMES^XPDUTL(" Not a production UCI") Q 0
+"RTN","XPDIST",49,0)
+ Q 1
+"RTN","XPDIST",50,0)
+REMEDY ;Send to Remedy Server - ESSRESOURCE@DOMAIN.EXT *p350 -REM
+"RTN","XPDIST",51,0)
+ Q:'XPDTRACK
+"RTN","XPDIST",52,0)
+ N XMY,XPDTEXT,XMTEXT,XMDUZ,XMSUB,XMZ,XMMG
+"RTN","XPDIST",53,0)
+ K ^TMP($J)
+"RTN","XPDIST",54,0)
+ S:XPY XMY("ESSRESOURCE@DOMAIN.EXT")=""
+"RTN","XPDIST",55,0)
+ S:$L($P(XPY,U,2)) XMY($P(XPY,U,2))=""
+"RTN","XPDIST",56,0)
+ ;Message for server (all in one string)
+"RTN","XPDIST",57,0)
+ ;XMTEXT=Type(1),Domain(2-65),Pkg(66-95),Version(96-125),
+"RTN","XPDIST",58,0)
+ ;       StartTime(126-147),CompleteTime(148-169),RunTime(170-177),
+"RTN","XPDIST",59,0)
+ ;       Date(178-199),InstalledBy(200-229),InstallName(230-259),
+"RTN","XPDIST",60,0)
+ ;       DistributionDate(260-281),Seq#(282-286),
+"RTN","XPDIST",61,0)
+ ;       PatchTestVersion(287-317)
+"RTN","XPDIST",62,0)
+ ;
+"RTN","XPDIST",63,0)
+ S X1=1_$G(^XMB("NETNAME")) ;Type is always "1"(1=patch,0=pkg).
+"RTN","XPDIST",64,0)
+ S $E(X1,66,95)=XPD,$E(X1,96,125)=XPDV,$E(X1,126,147)=XPZ(1),$E(X1,148,169)=XPZ(2),$E(X1,170,177)=XPZ(3),$E(X1,178,199)=DT
+"RTN","XPDIST",65,0)
+ S $E(X1,200,229)=$P($G(^VA(200,+$P(XPD0,U,11),0)),U),$E(X1,230,259)=$P(XPD0,U),$E(X1,260,281)=$P(XPD1,U,4),$E(X1,282,286)=$P(XPD6,U,2),$E(X1,287,317)=$P(XPD6,U)
+"RTN","XPDIST",66,0)
+ S XPDTEXT(1,0)=X1
+"RTN","XPDIST",67,0)
+ S XMDUZ=$S($P(XPD0,U,11):+$P(XPD0,U,11),1:.5),XMTEXT="XPDTEXT(",XMSUB="KIDS-"_$P(XPD0,U)_" INSTALLATION"
+"RTN","XPDIST",68,0)
+ D ^XMD
+"RTN","XPDIST",69,0)
+ Q
+"RTN","XPDIST",70,0)
+FORUM() ;EF. send to Server on FORUM
+"RTN","XPDIST",71,0)
+ Q:'XPDTRACK ""
+"RTN","XPDIST",72,0)
+ N XMY,XPDTEXT,XMTEXT,XMDUZ,XMSUB,XMZ,XMMG
+"RTN","XPDIST",73,0)
+ K ^TMP($J)
+"RTN","XPDIST",74,0)
+ S:XPY XMY("S.A5CSTS@FORUM.DOMAIN.EXT")=""
+"RTN","XPDIST",75,0)
+ S:$L($P(XPY,U,2)) XMY($P(XPY,U,2))=""
+"RTN","XPDIST",76,0)
+ ;Message for server
+"RTN","XPDIST",77,0)
+ S XPDTEXT(1,0)="PACKAGE INSTALL"
+"RTN","XPDIST",78,0)
+ S XPDTEXT(2,0)="SITE: "_$G(^XMB("NETNAME"))
+"RTN","XPDIST",79,0)
+ S XPDTEXT(3,0)="PACKAGE: "_XPD
+"RTN","XPDIST",80,0)
+ S XPDTEXT(4,0)="VERSION: "_XPDV
+"RTN","XPDIST",81,0)
+ S XPDTEXT(5,0)="Start time: "_XPZ(1)
+"RTN","XPDIST",82,0)
+ S XPDTEXT(6,0)="Completion time: "_XPZ(2)
+"RTN","XPDIST",83,0)
+ S XPDTEXT(7,0)="Run time: "_XPZ(3)
+"RTN","XPDIST",84,0)
+ S XPDTEXT(8,0)="DATE: "_DT
+"RTN","XPDIST",85,0)
+ S XPDTEXT(9,0)="Installed by: "_$P($G(^VA(200,+$P(XPD0,U,11),0)),U)
+"RTN","XPDIST",86,0)
+ S XPDTEXT(10,0)="Install Name: "_$P(XPD0,U)
+"RTN","XPDIST",87,0)
+ S XPDTEXT(11,0)="Distribution Date: "_$P(XPD1,U,4)
+"RTN","XPDIST",88,0)
+ S XPDTEXT(12,0)=XPD2
+"RTN","XPDIST",89,0)
+ S XPDTEXT(13,0)=+XPD6
+"RTN","XPDIST",90,0)
+ S XMDUZ=$S($P(XPD0,U,11):+$P(XPD0,U,11),1:.5),XMTEXT="XPDTEXT(",XMSUB=$P(XPD0,U)_" INSTALLATION"
+"RTN","XPDIST",91,0)
+ D ^XMD
+"RTN","XPDIST",92,0)
+ Q "#"_$G(XMZ)
+"RTN","XPDIST",93,0)
+ ;
+"RTN","XPDIST",94,0)
+CHKS(XPDPH,XPDTEXT) ;Get Checksum from Forum for patch XPDPH, XPDTEXT is passed by reference
+"RTN","XPDIST",95,0)
+ ;returns XPDTEXT(routine name)= before checksum
+"RTN","XPDIST",96,0)
+ ;need to create parameter to store url - future
+"RTN","XPDIST",97,0)
+ Q
+"RTN","XPDIST",98,0)
+ K ^TMP($J,"XPDTHC")
+"RTN","XPDIST",99,0)
+ Q:$G(XPDPH)=""
+"RTN","XPDIST",100,0)
+ N XPDCHK,XPDHDR,XPDURL,I,X,Y
+"RTN","XPDIST",101,0)
+ S XPDURL="http://127.0.0.1:82/cgi/PCHCSUM?PCH="_XPDPH,XPDCHK=0
+"RTN","XPDIST",102,0)
+ S X=$$GETURL^XTHC10(XPDURL,,$NA(^TMP($J,"XPDTHC")),.XPDHDR)
+"RTN","XPDIST",103,0)
+ I X>0 D
+"RTN","XPDIST",104,0)
+ . S I=""
+"RTN","XPDIST",105,0)
+ . F  S I=$O(^TMP($J,"XPDTHC",I)) Q:I=""  S X=$G(^(I)) D:$E(X,1,4)="<li>"
+"RTN","XPDIST",106,0)
+ .. S Y=$P($P(X,"</li>"),U,4),X=$P($P(X,"<li>",2),U),XPDTEXT(X)=Y,XPDCHK=XPDCHK+1
+"RTN","XPDIST",107,0)
+ . Q
+"RTN","XPDIST",108,0)
+ S XPDTEXT=XPDCHK
+"RTN","XPDIST",109,0)
+ K ^TMP($J,"XPDTHC")
+"RTN","XPDIST",110,0)
+ Q
+"RTN","XPDMENU")
+0^2^B5326422^B3839322
+"RTN","XPDMENU",1,0)
+XPDMENU ;SFISC/RWF,RSD - Manage Menu items ;11/02/2005  689530.624382
+"RTN","XPDMENU",2,0)
+ ;;8.0;KERNEL;**21,302,672**;Jul 10, 1995;Build 28
+"RTN","XPDMENU",3,0)
+ ;;Per VA Directive 6402, this routine should not be modified.
+"RTN","XPDMENU",4,0)
+ Q
+"RTN","XPDMENU",5,0)
+ ;
+"RTN","XPDMENU",6,0)
+ ;MENU=option to add to,  OPT=option to add to MENU, SYN=synonym
+"RTN","XPDMENU",7,0)
+ ;ORD=display order
+"RTN","XPDMENU",8,0)
+ADD(MENU,OPT,SYN,ORD) ;EF. Add options to a menu or extended action
+"RTN","XPDMENU",9,0)
+ Q:$G(MENU)']"" 0 Q:$G(OPT)']"" 0
+"RTN","XPDMENU",10,0)
+ N X,XPD1,XPD2,XPD3,DIC,DA,D0,DR,DLAYGO
+"RTN","XPDMENU",11,0)
+ S XPD1=$$LKOPT(MENU) Q:XPD1'>0 "0^no menu"
+"RTN","XPDMENU",12,0)
+ ;quit if type is not Broker, Menu or Extended action
+"RTN","XPDMENU",13,0)
+ I "BMX"'[$E($$TYPE(XPD1)_"~",1) Q "0^wrong type"
+"RTN","XPDMENU",14,0)
+ S XPD2=$$LKOPT(OPT) Q:XPD2'>0 "0^option not found"
+"RTN","XPDMENU",15,0)
+ ;if OPTion is not in menu, add it
+"RTN","XPDMENU",16,0)
+ I '$D(^DIC(19,XPD1,10,"B",XPD2)) D
+"RTN","XPDMENU",17,0)
+ .S X=XPD2,(D0,DA(1))=XPD1,DIC(0)="MLF",DIC("P")=$P(^DD(19,10,0),"^",2),DLAYGO=19,DIC="^DIC(19,"_XPD1_",10,"
+"RTN","XPDMENU",18,0)
+ .D FILE^DICN
+"RTN","XPDMENU",19,0)
+ S XPD3=$O(^DIC(19,XPD1,10,"B",XPD2,0))
+"RTN","XPDMENU",20,0)
+ I XPD3>0 S DR="" S:$G(SYN)]"" DR="2///"_SYN_";" S:$G(ORD)]"" DR=DR_"3///"_ORD I DR]"" S DIE="^DIC(19,"_XPD1_",10,",DA=XPD3,DA(1)=XPD1 D ^DIE
+"RTN","XPDMENU",21,0)
+ Q XPD3>0
+"RTN","XPDMENU",22,0)
+ ;
+"RTN","XPDMENU",23,0)
+LKOPT(X) ;EF.  To lookup on "B"
+"RTN","XPDMENU",24,0)
+ Q $O(^DIC(19,"B",X,0))
+"RTN","XPDMENU",25,0)
+ ;
+"RTN","XPDMENU",26,0)
+TYPE(X) ;EF. Return option type, Pass IFN.
+"RTN","XPDMENU",27,0)
+ Q:X'>0 "" Q $P($G(^DIC(19,X,0)),"^",4)
+"RTN","XPDMENU",28,0)
+ ;
+"RTN","XPDMENU",29,0)
+ ;MENU=option to delete from,  OPT=option to delete
+"RTN","XPDMENU",30,0)
+DELETE(MENU,OPT) ;EF. Delete item from menu or extended action.
+"RTN","XPDMENU",31,0)
+ Q:$G(MENU)']"" 0 Q:$G(OPT)']"" 0
+"RTN","XPDMENU",32,0)
+ N XPD1,XPD2,DIK,DA,X
+"RTN","XPDMENU",33,0)
+ S XPD1=$$LKOPT(MENU) Q:XPD1'>0 0
+"RTN","XPDMENU",34,0)
+ I "MX"'[$E($$TYPE(XPD1)_"~",1) Q 0
+"RTN","XPDMENU",35,0)
+ S XPD2=$$LKOPT(OPT) Q:XPD2'>0 0
+"RTN","XPDMENU",36,0)
+ S DA=$O(^DIC(19,XPD1,10,"B",XPD2,0)) Q:DA'>0 0
+"RTN","XPDMENU",37,0)
+ S DA(1)=XPD1,DIK="^DIC(19,XPD1,10," D ^DIK
+"RTN","XPDMENU",38,0)
+ Q 1
+"RTN","XPDMENU",39,0)
+ ;
+"RTN","XPDMENU",40,0)
+ ;OPT=option to set out of order,  TXT=message
+"RTN","XPDMENU",41,0)
+OUT(OPT,TXT) ;Set option out of order
+"RTN","XPDMENU",42,0)
+ Q:$G(OPT)']""
+"RTN","XPDMENU",43,0)
+ N XPD,XPD1
+"RTN","XPDMENU",44,0)
+ S XPD1=$$LKOPT(OPT) Q:XPD1'>0
+"RTN","XPDMENU",45,0)
+ S XPD(19,XPD1_",",2)=$G(TXT) D FILE^DIE("","XPD")
+"RTN","XPDMENU",46,0)
+ Q
+"RTN","XPDMENU",47,0)
+ ;
+"RTN","XPDMENU",48,0)
+ ;OLD=old name, NEW=new name
+"RTN","XPDMENU",49,0)
+RENAME(OLD,NEW) ;Rename option
+"RTN","XPDMENU",50,0)
+ Q:$G(OLD)']""  Q:$G(NEW)']""
+"RTN","XPDMENU",51,0)
+ N XPD,XPD1
+"RTN","XPDMENU",52,0)
+ S XPD1=$$LKOPT(OLD) Q:XPD1'>0
+"RTN","XPDMENU",53,0)
+ S XPD(19,XPD1_",",.01)=NEW D FILE^DIE("","XPD")
+"RTN","XPDMENU",54,0)
+ Q
+"RTN","XPDMENU",55,0)
+ ;
+"RTN","XPDMENU",56,0)
+ ;OPT=option name, TXT=Security Key, file 19.1
+"RTN","XPDMENU",57,0)
+LOCK(OPT,TXT) ;Set option LOCK
+"RTN","XPDMENU",58,0)
+ Q:$G(OPT)']""
+"RTN","XPDMENU",59,0)
+ N XPD,XPD1
+"RTN","XPDMENU",60,0)
+ S XPD1=$$LKOPT(OPT) Q:XPD1'>0
+"RTN","XPDMENU",61,0)
+ S XPD(19,XPD1_",",3)=$G(TXT) D FILE^DIE("E","XPD")
+"RTN","XPDMENU",62,0)
+ Q
+"RTN","XPDMENU",63,0)
+ ;
+"RTN","XPDMENU",64,0)
+ ;OPT=option name, TXT=Security Key, file 19.1
+"RTN","XPDMENU",65,0)
+RLOCK(OPT,TXT) ;Set option Reverse Lock
+"RTN","XPDMENU",66,0)
+ Q:$G(OPT)']""
+"RTN","XPDMENU",67,0)
+ N XPD,XPD1
+"RTN","XPDMENU",68,0)
+ S XPD1=$$LKOPT(OPT) Q:XPD1'>0
+"RTN","XPDMENU",69,0)
+ S XPD(19,XPD1_",",3.01)=$G(TXT) D FILE^DIE("E","XPD")
+"RTN","XPDMENU",70,0)
+ Q
+"RTN","XPDT")
+0^12^B64186009^B82909490
+"RTN","XPDT",1,0)
+XPDT ;SFISC/RSD - Transport a package ;02/12/2009
+"RTN","XPDT",2,0)
+ ;;8.0;KERNEL;**2,10,28,41,44,51,58,66,68,85,100,108,393,511,539,547,672**;Jul 10, 1995;Build 28
+"RTN","XPDT",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XPDT",4,0)
+EN ;build XTMP("XPDT",ien, XPDA=ien,XPDNM=name
+"RTN","XPDT",5,0)
+ ;XPDT(seq #)=ien^name^1=use current transport global on system
+"RTN","XPDT",6,0)
+ ;XPDT("DA",ien)=seq #
+"RTN","XPDT",7,0)
+ ;XPDVER=version number^package name
+"RTN","XPDT",8,0)
+ ;XPDGP=flag;global^flag;global^...  flag=1 replace global at site
+"RTN","XPDT",9,0)
+ N DIR,DIRUT,I,POP,XPD,XPDA,XPDERR,XPDGP,XPDGREF,XPDH,XPDH1,XPDHD,XPDI,XPDNM,XPDSEQ,XPDSIZ,XPDSIZA,XPDT,XPDTP,XPDVER
+"RTN","XPDT",10,0)
+ N DUOUT,DTOUT,XPDFMSG,X,Y,Z,Z1
+"RTN","XPDT",11,0)
+ K ^TMP($J,"XPD")
+"RTN","XPDT",12,0)
+ S XPD="First Package Name: ",DIR(0)="Y",DIR("A")="   Use this Transport Global",DIR("?")="Yes, will use the current Transport Global on your system. No, will create a new one.",XPDT=0
+"RTN","XPDT",13,0)
+ W !!,"Enter the Package Names to be transported. The order in which",!,"they are entered will be the order in which they are installed.",!!
+"RTN","XPDT",14,0)
+ F  S XPDA=$$DIC^XPDE("AEMQZ",XPD) Q:'XPDA  D  Q:$D(DIRUT)!$D(XPDERR)
+"RTN","XPDT",15,0)
+ .S:'XPDT XPD="Another Package Name: "
+"RTN","XPDT",16,0)
+ .;XPDI=name^1=use current transport global
+"RTN","XPDT",17,0)
+ .S XPDI=$P(Y(0),U)_"^"
+"RTN","XPDT",18,0)
+ .I $D(XPDT("DA",XPDA)) W "   ",$P(Y(0),U)," already listed",! Q
+"RTN","XPDT",19,0)
+ .;if type is Global Package, set DIRUT if there is other packages
+"RTN","XPDT",20,0)
+ .I $P(Y(0),U,3)=2 W "   GLOBAL PACKAGE" D  Q
+"RTN","XPDT",21,0)
+ ..;if there is already a package in distribution, abort
+"RTN","XPDT",22,0)
+ ..I XPDT S DIRUT=1 W !,"A GLOBAL PACKAGE cannot be sent with any other packages" Q
+"RTN","XPDT",23,0)
+ ..I $D(^XTMP("XPDT",XPDA)) W "  **Cannot have a pre-existing Transport Global**" S DIRUT=1 Q
+"RTN","XPDT",24,0)
+ ..W !?10,"will transport the following globals:",! S X=0,XPDGP=""
+"RTN","XPDT",25,0)
+ ..F  S X=$O(^XPD(9.6,XPDA,"GLO",X)) Q:'X  S Z=$G(^(X,0)) I $P(Z,U)]"" S XPDGP=XPDGP_($P(Z,U,2)="y")_";"_$P(Z,U)_"^" W ?12,$P(Z,U),!
+"RTN","XPDT",26,0)
+ ..;XPDERR is set to quit loop, so no other packages can be added
+"RTN","XPDT",27,0)
+ ..S XPDERR=1,XPDT=XPDT+1,XPDT(XPDT)=XPDA_U_XPDI,XPDT("DA",XPDA)=XPDT
+"RTN","XPDT",28,0)
+ .Q:$D(XPDERR)
+"RTN","XPDT",29,0)
+ .D PCK(XPDA,XPDI)
+"RTN","XPDT",30,0)
+ .;multi-package
+"RTN","XPDT",31,0)
+ .Q:$P(Y(0),U,3)'=1
+"RTN","XPDT",32,0)
+ .W "   (Multi-Package)" S X=0
+"RTN","XPDT",33,0)
+ .I XPDT>1 S DIRUT=1 W !,"A Master Build must be the first/only package in a transport" Q
+"RTN","XPDT",34,0)
+ .F  S X=$O(^XPD(9.6,XPDA,10,X)) Q:'X  S Z=$P($G(^(X,0)),U),Z1=$P($G(^(0)),U,2) D:Z]""
+"RTN","XPDT",35,0)
+ ..N XPDA,X
+"RTN","XPDT",36,0)
+ ..W !?3,Z S XPDA=$O(^XPD(9.6,"B",Z,0))
+"RTN","XPDT",37,0)
+ ..I 'XPDA W "  **Can't find definition in Build file**" Q
+"RTN","XPDT",38,0)
+ ..I $D(XPDT("DA",XPDA)) W "  already listed" Q
+"RTN","XPDT",39,0)
+ ..D PCK(XPDA,Z,Z1)
+"RTN","XPDT",40,0)
+ .S XPDERR=1 ;XPDERR is set to quit loop, so no other packages can be added
+"RTN","XPDT",41,0)
+ .Q
+"RTN","XPDT",42,0)
+ G:'XPDT!$D(DIRUT) QUIT K XPDERR
+"RTN","XPDT",43,0)
+ W !!,"ORDER   PACKAGE",!
+"RTN","XPDT",44,0)
+ F XPDT=1:1:XPDT S Y=$P(XPDT(XPDT),U,2) W ?2,XPDT,?7,Y D  W !
+"RTN","XPDT",45,0)
+ .W:$P(XPDT(XPDT),U,3) "     **will use current Transport Global**"
+"RTN","XPDT",46,0)
+ .;check if New Version and single package, has Package File Link, Package App. History
+"RTN","XPDT",47,0)
+ .Q:Y["*"!'$$PAH(+XPDT(XPDT))
+"RTN","XPDT",48,0)
+ .S DIR(0)="Y",DIR("A")="Send the PATCH APPLICATION HISTORY from the PACKAGE file",DIR("B")="YES"
+"RTN","XPDT",49,0)
+ .W !! D ^DIR I 'Y S $P(XPDT(XPDT),U,5)=1
+"RTN","XPDT",50,0)
+ S DIR(0)="Y",DIR("A")="OK to continue",DIR("B")="YES",XPDH=""
+"RTN","XPDT",51,0)
+ W !! D ^DIR G:$D(DIRUT)!'Y QUIT K DIR
+"RTN","XPDT",52,0)
+ I $G(XPDTP),XPDT>1 W !!,"You cannot send multiple Builds through PackMan."
+"RTN","XPDT",53,0)
+ S DIR(0)="SAO^HF:Host File"_$S(XPDT=1:";PM:PackMan",1:"")
+"RTN","XPDT",54,0)
+ S DIR("A")="Transport through (HF)Host File"_$S(XPDT=1:" or (PM)PackMan: ",1:": ")
+"RTN","XPDT",55,0)
+ S DIR("?")="Enter the method of transport for the package(s)."
+"RTN","XPDT",56,0)
+ D ^DIR G:$D(DTOUT)!$D(DUOUT) QUIT K DIR
+"RTN","XPDT",57,0)
+ I Y="" W !,"No Transport Method selected, will only write Transport Global to ^XTMP." S XPDH=""
+"RTN","XPDT",58,0)
+ ;XPDTP = transports using Packman
+"RTN","XPDT",59,0)
+ S:Y="PM" XPDTP=1
+"RTN","XPDT",60,0)
+ I $D(XPDGP),Y'="HF" W !,"**Global Package can only be sent with a Host File, Transport ABORTED**" Q
+"RTN","XPDT",61,0)
+ I Y="HF" D DEV G:POP QUIT
+"RTN","XPDT",62,0)
+ W !!
+"RTN","XPDT",63,0)
+ F XPDT=1:1:XPDT S XPDA=XPDT(XPDT),XPDNM=$P(XPDA,U,2) D  G:$D(XPDERR) ABORT
+"RTN","XPDT",64,0)
+ .W !?5,XPDNM,"..." S XPDGREF="^XTMP(""XPDT"","_+XPDA_",""TEMP"")"
+"RTN","XPDT",65,0)
+ .;if using current transport global, run pre-transp routine and quit
+"RTN","XPDT",66,0)
+ .I $P(XPDA,U,3) S XPDA=+XPDA D PRET Q
+"RTN","XPDT",67,0)
+ .;if package file link then set XPDVER=version number^package name
+"RTN","XPDT",68,0)
+ .S XPDA=+XPDA,XPDVER=$S($P(^XPD(9.6,XPDA,0),U,2):$$VER^XPDUTL(XPDNM)_U_$$PKG^XPDUTL(XPDNM),1:"")
+"RTN","XPDT",69,0)
+ .;Inc the Build number
+"RTN","XPDT",70,0)
+ .S $P(^XPD(9.6,XPDA,6.3),U)=$G(^XPD(9.6,XPDA,6.3))+1
+"RTN","XPDT",71,0)
+ .K ^XTMP("XPDT",XPDA)
+"RTN","XPDT",72,0)
+ .;GLOBAL PACKAGE
+"RTN","XPDT",73,0)
+ .I $D(XPDGP) D  S XPDT=1 Q
+"RTN","XPDT",74,0)
+ ..;can't send global package in packman message
+"RTN","XPDT",75,0)
+ ..I $G(XPDTP) S XPDERR=1 Q
+"RTN","XPDT",76,0)
+ ..;verify global package
+"RTN","XPDT",77,0)
+ ..I '$$GLOPKG^XPDV(XPDA) S XPDERR=1 Q
+"RTN","XPDT",78,0)
+ ..;get Environment check and Post Install routines
+"RTN","XPDT",79,0)
+ ..F Y="PRE","INIT" I $G(^XPD(9.6,XPDA,Y))]"" S X=^(Y) D
+"RTN","XPDT",80,0)
+ ...S ^XTMP("XPDT",XPDA,Y)=X,X=$P(X,U,$L(X,U)),%=$$LOAD^XPDTA(X,"0^")
+"RTN","XPDT",81,0)
+ ..D BLD^XPDTC,PRET
+"RTN","XPDT",82,0)
+ .F X="DD^XPDTC","KRN^XPDTC","QUES^XPDTC","INT^XPDTC","BLD^XPDTC" D @X Q:$D(XPDERR)
+"RTN","XPDT",83,0)
+ .D:'$D(XPDERR) PRET
+"RTN","XPDT",84,0)
+ ;XPDTP - call ^XPDTP to build Packman message
+"RTN","XPDT",85,0)
+ I $G(XPDTP) S XPDA=+XPDT(XPDT) D ^XPDTP G QUIT
+"RTN","XPDT",86,0)
+ I $L(XPDH) D GO G QUIT
+"RTN","XPDT",87,0)
+ ;if no device then just create transport global
+"RTN","XPDT",88,0)
+ W !! F XPDT=1:1:XPDT W "Transport Global ^XTMP(""XPDT"","_+XPDT(XPDT)_") created for ",$P(XPDT(XPDT),U,2),!
+"RTN","XPDT",89,0)
+ Q
+"RTN","XPDT",90,0)
+DEV N FIL,DIR,IOP,X,Y,%ZIS W !
+"RTN","XPDT",91,0)
+ D HOME^%ZIS
+"RTN","XPDT",92,0)
+ S DIR(0)="F^3:245",DIR("A")="Enter a Host File",DIR("?")="Enter a filename and/or path to output package(s).",POP=0
+"RTN","XPDT",93,0)
+ D ^DIR I $D(DTOUT)!$D(DUOUT) S POP=1 Q
+"RTN","XPDT",94,0)
+ ;if no file, then quit
+"RTN","XPDT",95,0)
+ Q:Y=""  S FIL=Y
+"RTN","XPDT",96,0)
+ S DIR(0)="F^3:80",DIR("A")="Header Comment",DIR("?")="Enter a comment between 3 and 80 characters."
+"RTN","XPDT",97,0)
+ D ^DIR I $D(DIRUT) S POP=1 Q
+"RTN","XPDT",98,0)
+ S XPDH=Y,%ZIS="",%ZIS("HFSNAME")=FIL,%ZIS("HFSMODE")="W",IOP="HFS",(XPDSIZ,XPDSIZA)=0,XPDSEQ=1
+"RTN","XPDT",99,0)
+ D ^%ZIS I POP W !!,"**Incorrect Host File name**",!,$C(7) Q
+"RTN","XPDT",100,0)
+ ;write date and comment header
+"RTN","XPDT",101,0)
+ S XPDHD="KIDS Distribution saved on "_$$HTE^XLFDT($H)
+"RTN","XPDT",102,0)
+ U IO W $$SUM(XPDHD),!,$$SUM(XPDH),!
+"RTN","XPDT",103,0)
+ S XPDFMSG=1 ;Send mail to forum of routines in HFS.
+"RTN","XPDT",104,0)
+ ;U IO(0) is to insure I am writing to the terminal
+"RTN","XPDT",105,0)
+ U IO(0) Q
+"RTN","XPDT",106,0)
+ ;
+"RTN","XPDT",107,0)
+GO S I=1,Y="",XPDH1="**KIDS**:" U IO
+"RTN","XPDT",108,0)
+ ;Global Package, header is different and there is only 1 package
+"RTN","XPDT",109,0)
+ I $D(XPDGP) W $$SUM("**KIDS**GLOBALS:"_$P(XPDT(1),U,2)_U_XPDGP),! G GO1
+"RTN","XPDT",110,0)
+ ;write header that maintains package list, keep less than 255 char
+"RTN","XPDT",111,0)
+ F  D  W $$SUM(XPDH1_Y),! Q:I=XPDT  S Y="",I=I+1,XPDH1="**KIDS**"
+"RTN","XPDT",112,0)
+ .F I=I:1 S Y=Y_$P(XPDT(I),U,2)_"^" Q:$L(Y)>200!(I=XPDT)
+"RTN","XPDT",113,0)
+ ;after the package list write an extra line feed
+"RTN","XPDT",114,0)
+GO1 W ! S XPDSIZA=XPDSIZA+2
+"RTN","XPDT",115,0)
+ N XMSUB,XMY,XMTEXT
+"RTN","XPDT",116,0)
+ ;loop thru & write global, don't kill if set to permanent, set in XPDIU
+"RTN","XPDT",117,0)
+ F XPDT=1:1:XPDT S XPDA=+XPDT(XPDT),XPDNM=$P(XPDT(XPDT),U,2) D GW,XM K:'$G(^XTMP("XPDT",XPDA)) ^(XPDA)
+"RTN","XPDT",118,0)
+ W "**END**",!
+"RTN","XPDT",119,0)
+ ;GLOBAL PACKAGE there could only be one package, write globals
+"RTN","XPDT",120,0)
+ I $D(XPDGP) D GPW W "**END**",!
+"RTN","XPDT",121,0)
+ ;we're done with device, close it
+"RTN","XPDT",122,0)
+ W "**END**",! D ^%ZISC
+"RTN","XPDT",123,0)
+ W !!,"Package Transported Successfully",!
+"RTN","XPDT",124,0)
+ Q
+"RTN","XPDT",125,0)
+GW ;global write
+"RTN","XPDT",126,0)
+ N GR,GCK,GL
+"RTN","XPDT",127,0)
+ S GCK="^XTMP(""XPDT"","_XPDA,GR=GCK_")",GCK=GCK_",",GL=$L(GCK)
+"RTN","XPDT",128,0)
+ ;INSTALL NAME line will mark the beginning of global for all lines until
+"RTN","XPDT",129,0)
+ ;the next INSTALL NAME
+"RTN","XPDT",130,0)
+ W $$SUM("**INSTALL NAME**",1),!,$$SUM(XPDNM),!
+"RTN","XPDT",131,0)
+ F  Q:$D(DIRUT)  S GR=$Q(@GR) Q:GR=""!($E(GR,1,GL)'=GCK)  W $$SUM($P(GR,GCK,2),1),!,$$SUM(@GR),!
+"RTN","XPDT",132,0)
+ Q
+"RTN","XPDT",133,0)
+XM ;Send HFS checksum message
+"RTN","XPDT",134,0)
+ Q:'$G(XPDFMSG)
+"RTN","XPDT",135,0)
+ N XMTEXT,C,RN,RN2,X,X2
+"RTN","XPDT",136,0)
+ K ^TMP($J)
+"RTN","XPDT",137,0)
+ S XMSUB="**KIDS** Checksum for "_XPDNM,XMTEXT="^TMP($J)"
+"RTN","XPDT",138,0)
+ I $G(^XMB("NETNAME"))["DOMAIN.EXT" S XMY("S.A1AE HFS CHKSUM SVR@FORUM.DOMAIN.EXT")=""
+"RTN","XPDT",139,0)
+ E  S X=$$GET^XPAR("PKG","XPD PATCH HFS SERVER",1,"Q") S:$L(X) XMY(X)=""
+"RTN","XPDT",140,0)
+ I '$D(XMY) Q  ;No one to send it to.
+"RTN","XPDT",141,0)
+ S C=1,@XMTEXT@(1,0)="~~1:"_XPDNM
+"RTN","XPDT",142,0)
+ I XPDT=1,$O(XPDT(1)) D
+"RTN","XPDT",143,0)
+ . S RN=1 F  S RN=$O(XPDT(RN)) Q:'RN  S C=C+1,@XMTEXT@(C,0)="~~2:"_$P(XPDT(RN),"^",2)
+"RTN","XPDT",144,0)
+ S (RN,RN2)="" ;Send full RTN node
+"RTN","XPDT",145,0)
+ F  S RN=$O(^XTMP("XPDT",XPDA,"RTN",RN)) Q:'$L(RN)  S X=^(RN),X2=$G(^(RN,2,0)) D
+"RTN","XPDT",146,0)
+ . S C=C+1,@XMTEXT@(C,0)="~~3:"_RN_"^"_X_"^"_$P(X2,";",5)
+"RTN","XPDT",147,0)
+ . I RN2="",$E(X2,1,3)=" ;;" S RN2=$P(X2,"**",1)_"**[Patch List]**"_$P(X2,"**",3)
+"RTN","XPDT",148,0)
+ S C=C+1,@XMTEXT@(C,0)="~~4:"_RN2
+"RTN","XPDT",149,0)
+ S C=C+1,@XMTEXT@(C,0)="~~8:"_$G(^XMB("NETNAME"))
+"RTN","XPDT",150,0)
+ S C=C+1,@XMTEXT@(C,0)="~~9:Save"
+"RTN","XPDT",151,0)
+ S XMTEXT="^TMP($J,"
+"RTN","XPDT",152,0)
+ D ^XMD
+"RTN","XPDT",153,0)
+ Q
+"RTN","XPDT",154,0)
+GPW ;global package write
+"RTN","XPDT",155,0)
+ N I,G,GR,GCK,GL
+"RTN","XPDT",156,0)
+ W !
+"RTN","XPDT",157,0)
+ F I=1:1 S G=$P(XPDGP,U,I) Q:G=""  D
+"RTN","XPDT",158,0)
+ .S GR="^"_$P(G,";",2),GCK=$S(GR[")":$E(GR,1,$L(GR)-1)_",",1:GR_"("),GL=$L(GCK)
+"RTN","XPDT",159,0)
+ .;GLOBAL line will mark the beginning of global for all lines until
+"RTN","XPDT",160,0)
+ .;the next GLOBAL
+"RTN","XPDT",161,0)
+ .W $$SUM("**GLOBAL**",1),!,$$SUM(GR),!
+"RTN","XPDT",162,0)
+ .F  Q:$D(DIRUT)  S GR=$Q(@GR) Q:GR=""!($E(GR,1,GL)'=GCK)  W $$SUM($P(GR,GCK,2),1),!,$$SUM(@GR),!
+"RTN","XPDT",163,0)
+ Q
+"RTN","XPDT",164,0)
+QUIT F XPDT=1:1:XPDT L -^XPD(9.6,+XPDT(XPDT))
+"RTN","XPDT",165,0)
+ Q
+"RTN","XPDT",166,0)
+ABORT W !!,"**TRANSPORT ABORTED**",*7
+"RTN","XPDT",167,0)
+ D QUIT
+"RTN","XPDT",168,0)
+ F XPDT=1:1:XPDT K ^XTMP("XPDT",+XPDT(XPDT))
+"RTN","XPDT",169,0)
+ ;if HF, save file name IO into XPDH
+"RTN","XPDT",170,0)
+ S:$L(XPDH) XPDH=IO
+"RTN","XPDT",171,0)
+ D ^%ZISC
+"RTN","XPDT",172,0)
+ ;if HF, then delete file
+"RTN","XPDT",173,0)
+ I $L(XPDH),$$DEL1^%ZISH(XPDH) W !,"File:  ",XPDH,"  (Deleted)"
+"RTN","XPDT",174,0)
+ Q
+"RTN","XPDT",175,0)
+ ;
+"RTN","XPDT",176,0)
+PCK(XPDA,XPDNM,XPDREQ) ;XPDA=Build ien, XPDNM=Build name, XPDREQ=Required
+"RTN","XPDT",177,0)
+ N Y
+"RTN","XPDT",178,0)
+ S XPDT=XPDT+1,XPDT(XPDT)=XPDA_U_XPDNM,XPDT("DA",XPDA)=XPDT
+"RTN","XPDT",179,0)
+ S:'$G(XPDREQ) XPDREQ=0
+"RTN","XPDT",180,0)
+ S $P(XPDT(XPDT),U,4)=XPDREQ
+"RTN","XPDT",181,0)
+ Q:'$D(^XTMP("XPDT",XPDA))  S Y=$G(^(XPDA))
+"RTN","XPDT",182,0)
+ W "     **Transport Global exists**"
+"RTN","XPDT",183,0)
+ ;Y=1 if TG is permanent
+"RTN","XPDT",184,0)
+ I Y S $P(XPDT(XPDT),U,3)=1 Q
+"RTN","XPDT",185,0)
+ ;ask if they want to use TG
+"RTN","XPDT",186,0)
+ D ^DIR S $P(XPDT(XPDT),U,3)=Y
+"RTN","XPDT",187,0)
+ Q
+"RTN","XPDT",188,0)
+ ;
+"RTN","XPDT",189,0)
+SUM(X,Z) ;X=string to write, Z 0=don't check size
+"RTN","XPDT",190,0)
+ S XPDSIZA=XPDSIZA+$L(X)+2
+"RTN","XPDT",191,0)
+ Q X
+"RTN","XPDT",192,0)
+ ;
+"RTN","XPDT",193,0)
+PAH(XPDA) ;check for PATCH APPLICATION HISTORY in Package file
+"RTN","XPDT",194,0)
+ N Y,Z
+"RTN","XPDT",195,0)
+ S Y=^XPD(9.6,XPDA,0),Z=$$VER^XPDUTL($P(Y,U))
+"RTN","XPDT",196,0)
+ ;Single Package, Version multiple, PAH multiple
+"RTN","XPDT",197,0)
+ I $P(Y,U,3)=0,$D(^DIC(9.4,+$P(Y,U,2),22)),Z S Z=$O(^(22,"B",Z,0)) I Z,$O(^DIC(9.4,+$P(Y,U,2),22,Z,"PAH",0)) Q 1
+"RTN","XPDT",198,0)
+ Q 0
+"RTN","XPDT",199,0)
+ ;
+"RTN","XPDT",200,0)
+PRET ;Pre-Transport Routine
+"RTN","XPDT",201,0)
+ N Y,Z
+"RTN","XPDT",202,0)
+ S Y=$G(^XPD(9.6,XPDA,"PRET")) Q:Y=""
+"RTN","XPDT",203,0)
+ I '$$RTN^XPDV(Y,.Z) W !!,"Pre-Transportation Routine ",Y,Z,*7 Q
+"RTN","XPDT",204,0)
+ S Y=$S(Y["^":Y,1:"^"_Y) W !,"Running Pre-Transportation Routine ",Y
+"RTN","XPDT",205,0)
+ D @Y
+"RTN","XPDT",206,0)
+ Q
+"RTN","XPDTA2")
+0^9^B18380713^B6421820
+"RTN","XPDTA2",1,0)
+XPDTA2 ;SFISC/RWF -  Build Actions for Kernel Files Cont. ;08/09/2001  12:36
+"RTN","XPDTA2",2,0)
+ ;;8.0;KERNEL;**201,498,672**;Jul 10, 1995;Build 28
+"RTN","XPDTA2",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XPDTA2",4,0)
+ Q
+"RTN","XPDTA2",5,0)
+ ;^XTMP("XPDT",XPDA,"KRN",XPDFILE,DA) is the global root
+"RTN","XPDTA2",6,0)
+ ;DA=ien in ^XTMP,XPDNM=package name, XPDA=package ien in ^XPD(9.6,
+"RTN","XPDTA2",7,0)
+ ;
+"RTN","XPDTA2",8,0)
+PAR1E1 ;PARAMETER DEFINITION file 8989.51: entry post
+"RTN","XPDTA2",9,0)
+ N XP,XP1,XP2,XP3,XP4,VP,PN,PT,ROOT
+"RTN","XPDTA2",10,0)
+ S ROOT=$NA(^XTMP("XPDT",XPDA,"KRN"))
+"RTN","XPDTA2",11,0)
+ D PAR51(DA) ;Handle the entry from 8989.51
+"RTN","XPDTA2",12,0)
+ S PT=$S($E($G(^XTV(8989.51,DA,1)))="P":$P(^(1),U,2),1:"") ;Data Type & Value - check if pointer in for loop
+"RTN","XPDTA2",13,0)
+ S:PT]"" PT=$S(PT:$$GR^XPDTA(PT),1:"") ;PT=file # of pointed to file from parm def.
+"RTN","XPDTA2",14,0)
+ ;Now find any entrys in 8989.5 to transport, because we point to them
+"RTN","XPDTA2",15,0)
+ S XP=0,XP3=$P(^XPD(9.6,XPDA,0),U,2),VP=XP3_";DIC(9.4,",PN=$$PT^XPDTA("^DIC(9.4)",XP3)
+"RTN","XPDTA2",16,0)
+ Q:'XP3  ;No package file link
+"RTN","XPDTA2",17,0)
+ F  S XP=$O(^XTV(8989.5,"AC",DA,VP,XP)),XP1=0 Q:'XP  D  ;Instance
+"RTN","XPDTA2",18,0)
+ . F  S XP1=$O(^XTV(8989.5,"AC",DA,VP,XP,XP1)) Q:'XP1  D  ;entry
+"RTN","XPDTA2",19,0)
+ . . M ^XTMP("XPDT",XPDA,"KRN",8989.5,XP1)=^XTV(8989.5,XP1)
+"RTN","XPDTA2",20,0)
+ . . S XP3=^XTV(8989.5,XP1,0),XP4=$G(^(1)) ;param def.
+"RTN","XPDTA2",21,0)
+ . . S $P(@ROOT@(8989.5,XP1,0),U,2)=$$PT^XPDTA("^XTV(8989.51)",$P(XP3,U,2))
+"RTN","XPDTA2",22,0)
+ . . I PT]"",XP4>0 S $P(@ROOT@(8989.5,XP1,1),U)=$$PT^XPDTA(PT,XP4) ;Data Type pointer - resolve
+"RTN","XPDTA2",23,0)
+ . . Q  ;Will redo the ENT at other end.
+"RTN","XPDTA2",24,0)
+ Q
+"RTN","XPDTA2",25,0)
+ ;
+"RTN","XPDTA2",26,0)
+PAR51(DA) ;Fix one 8989.51 entry in transport global
+"RTN","XPDTA2",27,0)
+ ;Called from both PAR1E1 and PAR2E1
+"RTN","XPDTA2",28,0)
+ N XP,XP1,XP2,XP3,VP,PN,ROOT
+"RTN","XPDTA2",29,0)
+ S ROOT=$NA(^XTMP("XPDT",XPDA,"KRN"))
+"RTN","XPDTA2",30,0)
+ ;Don't bring X-ref
+"RTN","XPDTA2",31,0)
+ K @ROOT@(8989.51,DA,30,"B"),^("AG")
+"RTN","XPDTA2",32,0)
+ S XP=0
+"RTN","XPDTA2",33,0)
+ ;Entries in the file will be maintained by Toolkit patches.
+"RTN","XPDTA2",34,0)
+ Q
+"RTN","XPDTA2",35,0)
+ ;
+"RTN","XPDTA2",36,0)
+PAR2E1 ;PARAMETER file 8989.52 entry post
+"RTN","XPDTA2",37,0)
+ N XP1,XP2,XP3,ROOT
+"RTN","XPDTA2",38,0)
+ S ROOT=$NA(^XTMP("XPDT",XPDA,"KRN"))
+"RTN","XPDTA2",39,0)
+ ;Resolve USE INSTANCE OF
+"RTN","XPDTA2",40,0)
+ S XP2=$P(^XTV(8989.52,DA,0),U,4),XP3="" I XP2 S XP3=$$PT^XPDTA($NA(^XTV(8989.51)),XP2)
+"RTN","XPDTA2",41,0)
+ I $L(XP3) S $P(@ROOT@(8989.52,DA,0),U,4)=XP3
+"RTN","XPDTA2",42,0)
+ ;Resolve PARAMETERS
+"RTN","XPDTA2",43,0)
+ S XP1=0 K ^XTMP("XPDT",XPDA,"KRN",8989.52,DA,10,"B") ;Drop X-ref
+"RTN","XPDTA2",44,0)
+ F  S XP1=$O(^XTV(8989.52,DA,10,XP1)),XP3="" Q:'XP1  D
+"RTN","XPDTA2",45,0)
+ . S XP2=$P(^XTV(8989.52,DA,10,XP1,0),U,2)
+"RTN","XPDTA2",46,0)
+ . I XP2 S XP3=$$PT^XPDTA($NA(^XTV(8989.51)),XP2)
+"RTN","XPDTA2",47,0)
+ . I '$L(XP3) K @ROOT@(8989.52,DA,10,XP1)
+"RTN","XPDTA2",48,0)
+ . S $P(^XTMP("XPDT",XPDA,"KRN",8989.52,DA,10,XP1,0),U,2)=XP3
+"RTN","XPDTA2",49,0)
+ . ;Now to move the entries this points to.
+"RTN","XPDTA2",50,0)
+ . I '$D(@ROOT@(8989.51,XP2)) M @ROOT@(8989.51,XP2)=^XTV(8989.51,XP2) D PAR51(XP2)
+"RTN","XPDTA2",51,0)
+ . Q
+"RTN","XPDTA2",52,0)
+ Q
+"RTN","XPDTA2",53,0)
+XULM ;XULM LOCK DICTIONARY file 8993
+"RTN","XPDTA2",54,0)
+ N XP1,XP2
+"RTN","XPDTA2",55,0)
+ ;resolve PACKAGE
+"RTN","XPDTA2",56,0)
+ S XP1=$P($G(^XTMP("XPDT",XPDA,"KRN",8993,DA,1)),U)
+"RTN","XPDTA2",57,0)
+ S:XP1 $P(^XTMP("XPDT",XPDA,"KRN",8993,DA,1),U)=$$PT^XPDTA("^DIC(9.4)",XP1)
+"RTN","XPDTA2",58,0)
+ ;kill X-ref
+"RTN","XPDTA2",59,0)
+ K ^XTMP("XPDT",XPDA,"KRN",8993,2,"B"),^XTMP("XPDT",XPDA,"KRN",8993,3,"B"),^("C")
+"RTN","XPDTA2",60,0)
+ Q
+"RTN","XPDTA2",61,0)
+ ;
+"RTN","XPDTA2",62,0)
+ENT ;ENTITY file 1.5
+"RTN","XPDTA2",63,0)
+ N %,%1
+"RTN","XPDTA2",64,0)
+ ;Loop thru ITEM multiple and resolve ENTITY (0;8)
+"RTN","XPDTA2",65,0)
+ S %1=0 F  S %1=$O(^XTMP("XPDT",XPDA,"KRN",1.5,DA,1,%1)) Q:'%1  S %=$G(^(%1,0)) D:$P(%,U,8)
+"RTN","XPDTA2",66,0)
+ . S $P(%,U,8)=$$PT^XPDTA("^DDE",$P(%,U,8)),^XTMP("XPDT",XPDA,"KRN",1.5,DA,1,%1,0)=%
+"RTN","XPDTA2",67,0)
+ Q
+"RTN","XPDTA2",68,0)
+ ;
+"RTN","XPDTA2",69,0)
+POL ;POLICY file 1.6
+"RTN","XPDTA2",70,0)
+ N %,%1,%2
+"RTN","XPDTA2",71,0)
+ ;if link, kill everything and just process the MEMBERS(10)
+"RTN","XPDTA2",72,0)
+ I XPDFL=2 D  G POLM
+"RTN","XPDTA2",73,0)
+ .S %1=0 F  S %1=$O(^XTMP("XPDT",XPDA,"KRN",1.6,DA,%1)) Q:'%1  K:%1'=10 ^(%)
+"RTN","XPDTA2",74,0)
+ .Q
+"RTN","XPDTA2",75,0)
+ ;resolve ATTRIBUTE FUNCTION (0;4) and RESULT FUNCTION (0;7)
+"RTN","XPDTA2",76,0)
+ S %=^XTMP("XPDT",XPDA,"KRN",1.6,DA,0) D  S ^XTMP("XPDT",XPDA,"KRN",1.6,DA,0)=%
+"RTN","XPDTA2",77,0)
+ .F %1=4,7 S %2=$P(%,U,%1),$P(%,U,%1)=$$PT^XPDTA("^DIAC(1.62)",%2)
+"RTN","XPDTA2",78,0)
+ .Q
+"RTN","XPDTA2",79,0)
+ ;resolve DENY OBLIGATION (7) and PERMIT OBLIGATION (8)
+"RTN","XPDTA2",80,0)
+ F %1=7,8 S %=$G(^XTMP("XPDT",XPDA,"KRN",1.6,DA,%1)) D:$L(%)
+"RTN","XPDTA2",81,0)
+ .S %2=$P(%,U),$P(%,U)=$$PT^XPDTA("^DIAC(1.62)",%2)
+"RTN","XPDTA2",82,0)
+ .S ^XTMP("XPDT",XPDA,"KRN",1.6,DA,%1)=%
+"RTN","XPDTA2",83,0)
+ .Q
+"RTN","XPDTA2",84,0)
+ ;kill under TAGETS (2) ^("B"),^("AKEY")
+"RTN","XPDTA2",85,0)
+ I $O(^XTMP("XPDT",XPDA,"KRN",1.6,DA,2,0)) K ^("B"),^("AKEY")
+"RTN","XPDTA2",86,0)
+ ;check if CONDITIONS (3) are sent, if yes then kill ^("B") and process
+"RTN","XPDTA2",87,0)
+ I $O(^XTMP("XPDT",XPDA,"KRN",1.6,DA,3,0)) K ^("B") D
+"RTN","XPDTA2",88,0)
+ .;loop thru and resolve FUNCTION (0;2)
+"RTN","XPDTA2",89,0)
+ .S %1=0 F  S %1=$O(^XTMP("XPDT",XPDA,"KRN",1.6,DA,3,%1)) Q:'%1  S %=$G(^(%1,0)) D
+"RTN","XPDTA2",90,0)
+ ..S %2=$P(%,U,2) Q:'%2
+"RTN","XPDTA2",91,0)
+ ..S $P(%,U,2)=$$PT^XPDTA("^DIAC(1.62)",%2)
+"RTN","XPDTA2",92,0)
+ ..S ^XTMP("XPDT",XPDA,"KRN",1.6,DA,3,%1,0)=%
+"RTN","XPDTA2",93,0)
+ .Q
+"RTN","XPDTA2",94,0)
+POLM ;loop thru 10=MEMEBERS and resolve MEMBER (0;1), kill if it doesn't resolve
+"RTN","XPDTA2",95,0)
+ Q:'$O(^XTMP("XPDT",XPDA,"KRN",1.6,DA,10,0))
+"RTN","XPDTA2",96,0)
+ ;kill under MEMBERS (10), "B"=name, "AC"=SEQUENCE
+"RTN","XPDTA2",97,0)
+ K ^XTMP("XPDT",XPDA,"KRN",1.6,DA,10,"B"),^("AC")
+"RTN","XPDTA2",98,0)
+ S %1=0 F  S %1=$O(^XTMP("XPDT",XPDA,"KRN",1.6,DA,10,%1)) Q:'%1  S %=$G(^(%1,0)) D
+"RTN","XPDTA2",99,0)
+ .S %2=$$PT^XPDTA("^DIAC(1.6)",+%)
+"RTN","XPDTA2",100,0)
+ .;MEMBER must also be sent by itself, check "B" x-ref, save text on U node
+"RTN","XPDTA2",101,0)
+ .I $L(%2),$D(^XPD(9.6,XPDA,"KRN",1.6,"NM","B",%2)) S ^XTMP("XPDT",XPDA,"KRN",1.6,DA,10,%1,U)=%2 Q
+"RTN","XPDTA2",102,0)
+ .K ^XTMP("XPDT",XPDA,"KRN",1.6,DA,10,%1)
+"RTN","XPDTA2",103,0)
+ .Q
+"RTN","XPDTA2",104,0)
+ Q
+"RTN","XPDTA2",105,0)
+ ;
+"RTN","XPDTA2",106,0)
+POLE ;EVENT #1.61
+"RTN","XPDTA2",107,0)
+ N %,%1,%2
+"RTN","XPDTA2",108,0)
+ S %=^XTMP("XPDT",XPDA,"KRN",1.61,DA,0)
+"RTN","XPDTA2",109,0)
+ ;resolve POLICY (0;5)
+"RTN","XPDTA2",110,0)
+ S %1=$P(%,U,5) Q:'%1
+"RTN","XPDTA2",111,0)
+ S %2=$$PT^XPDTA("^DIAC(1.6)",%1),$P(%,U,5)=%2,^XTMP("XPDT",XPDA,"KRN",1.61,DA,0)=%
+"RTN","XPDTA2",112,0)
+ Q
+"RTN","XPDTA2",113,0)
+ ;
+"RTN","XPDTA2",114,0)
+POLF ;FUNCTION #1.62
+"RTN","XPDTA2",115,0)
+ Q
+"RTN","XPDTC")
+0^7^B46881298^B47613677
+"RTN","XPDTC",1,0)
+XPDTC ;SFISC/RSD - Transport calls ;10/15/2008
+"RTN","XPDTC",2,0)
+ ;;8.0;KERNEL;**10,15,21,39,41,44,58,83,92,95,100,108,124,131,463,511,517,559,672**;Jul 10, 1995;Build 28
+"RTN","XPDTC",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XPDTC",4,0)
+ Q
+"RTN","XPDTC",5,0)
+ ;^XTMP("XPDT",XPDA,data type,file #,
+"RTN","XPDTC",6,0)
+ ;XPDA=ien of File 9.6, XPDNM=.01 field
+"RTN","XPDTC",7,0)
+DD ;build DD
+"RTN","XPDTC",8,0)
+ N FILE,FGR,FNAM,Z2,Z3,Z4
+"RTN","XPDTC",9,0)
+ S FILE=0,FGR="^XTMP(""XPDT"",XPDA)",FNAM=$NA(^XPD(9.6,XPDA,4,"APDD"))
+"RTN","XPDTC",10,0)
+ F  S FILE=$O(^XPD(9.6,XPDA,4,FILE)) Q:'FILE  D
+"RTN","XPDTC",11,0)
+ .S Z2=$G(^XPD(9.6,XPDA,4,FILE,222)),Z3=$G(^(223)),Z4=$G(^(224))
+"RTN","XPDTC",12,0)
+ .Q:'$$DATA^XPDV(FILE,Z2)
+"RTN","XPDTC",13,0)
+ .D FIA^DIFROMSU(FILE,"",FNAM,FGR,Z2,Z3,Z4,XPDVER),DIERR:$D(DIERR)
+"RTN","XPDTC",14,0)
+ Q:'$D(^XTMP("XPDT",XPDA,"FIA"))
+"RTN","XPDTC",15,0)
+ ;send DD and Data
+"RTN","XPDTC",16,0)
+ D DDOUT^DIFROMS("","","",FGR),DIERR:$D(DIERR),DATAOUT^DIFROMS("","","",FGR),DIERR:$D(DIERR)
+"RTN","XPDTC",17,0)
+ Q
+"RTN","XPDTC",18,0)
+ ;XPDERR is checked in XPDT and will abort transport
+"RTN","XPDTC",19,0)
+DIERR ;record error
+"RTN","XPDTC",20,0)
+ D MSG^DIALOG("EW",.XPD) S XPDERR=1
+"RTN","XPDTC",21,0)
+ Q
+"RTN","XPDTC",22,0)
+KRN ;build Kernel Files
+"RTN","XPDTC",23,0)
+ ;XPDFILE=file #, XPDOLDA=ien in Build file
+"RTN","XPDTC",24,0)
+ N %,%1,%2,DA,EACT,FACT,FGR,XPDFILE,XPDFL,XPDOLDA,XPDI
+"RTN","XPDTC",25,0)
+ F XPDFILE=1:1 S Y0=$P($T(FILES+XPDFILE^XPDE),";;",2,99) Q:Y0=""  S XPDI(+Y0)=Y0
+"RTN","XPDTC",26,0)
+ ;XPDI(XPDFILE)=file;order;x-ref;fact;eact;fpre;epre;fpos;epos;fdel
+"RTN","XPDTC",27,0)
+ S XPDFILE=0
+"RTN","XPDTC",28,0)
+ ;check we are sending something and have the executes
+"RTN","XPDTC",29,0)
+ F  S XPDFILE=$O(^XPD(9.6,XPDA,"KRN",XPDFILE)) Q:'XPDFILE  S XPDI=$G(XPDI(XPDFILE)) I $O(^(XPDFILE,"NM",0)),XPDI D  Q:$D(XPDERR)  D:FACT]"" ACT(FACT)
+"RTN","XPDTC",30,0)
+ .S FACT=$P(XPDI,";",4),EACT=$P(XPDI,";",5)
+"RTN","XPDTC",31,0)
+ .;need to add code to check if File and data is already being sent in the File
+"RTN","XPDTC",32,0)
+ .;mult. If it is, don't bother sending it again.  DTL(XPDFILE)
+"RTN","XPDTC",33,0)
+ .S XPDOLDA=0,FGR=$$FILE^XPDV(XPDFILE) I FGR="" S XPDERR=1 Q
+"RTN","XPDTC",34,0)
+ .K ^TMP($J,"XPD")
+"RTN","XPDTC",35,0)
+ .F  S XPDOLDA=$O(^XPD(9.6,XPDA,"KRN",XPDFILE,"NM",XPDOLDA)) Q:'XPDOLDA  S Y0=$G(^(XPDOLDA,0)) D
+"RTN","XPDTC",36,0)
+ ..;XPDFL= 0-send,1-delete,2-link,3-merge,4-attach,5-disable
+"RTN","XPDTC",37,0)
+ ..S XPDFL=$P(Y0,U,3)
+"RTN","XPDTC",38,0)
+ ..;If deleting at site get an unused DA
+"RTN","XPDTC",39,0)
+ ..I XPDFL=1 S DA=$O(@FGR@(" "),-1)+1 F DA=DA:1 Q:'$D(^XTMP("XPDT",XPDA,"KRN",XPDFILE,DA))
+"RTN","XPDTC",40,0)
+ ..;$P(Y0,U,2) is file # for this template, reset Y0 before getting DA
+"RTN","XPDTC",41,0)
+ ..E  S:$P(Y0,U,2) $P(Y0,U)=$P(Y0,"    FILE #") S DA=$$ENTRY^XPDV(Y0)
+"RTN","XPDTC",42,0)
+ ..I 'DA S XPDERR=1 Q
+"RTN","XPDTC",43,0)
+ ..;(-1)=action ^ ien in Build file
+"RTN","XPDTC",44,0)
+ ..S ^XTMP("XPDT",XPDA,"KRN",XPDFILE,DA,-1)=+XPDFL_"^"_XPDOLDA
+"RTN","XPDTC",45,0)
+ ..;action 2 - verify children, 4 - verify parent
+"RTN","XPDTC",46,0)
+ ..I XPDFL=2!(XPDFL=4),'$$MENU^XPDV(XPDFILE,DA,XPDFL) S XPDERR=1 Q
+"RTN","XPDTC",47,0)
+ ..;if action is 1,4 or 5 then only send .01 field and set checksum to ""
+"RTN","XPDTC",48,0)
+ ..I XPDFL=1!(XPDFL>3) S ^XTMP("XPDT",XPDA,"KRN",XPDFILE,DA,0)=$P(Y0,U),$P(^XPD(9.6,XPDA,"KRN",XPDFILE,"NM",XPDOLDA,0),U,4)="" Q
+"RTN","XPDTC",49,0)
+ ..M ^XTMP("XPDT",XPDA,"KRN",XPDFILE,DA)=@FGR@(DA)
+"RTN","XPDTC",50,0)
+ ..;execute entry build action
+"RTN","XPDTC",51,0)
+ ..D:EACT]"" ACT(EACT)
+"RTN","XPDTC",52,0)
+ .;quit if no entries were saved
+"RTN","XPDTC",53,0)
+ .Q:'$O(^XTMP("XPDT",XPDA,"KRN",XPDFILE,0))
+"RTN","XPDTC",54,0)
+ .;XPDI=XPDI(XPDFILE), build x-ref of order to install
+"RTN","XPDTC",55,0)
+ .S %=$P(^DIC(XPDFILE,0),U),^XTMP("XPDT",XPDA,"ORD",+$P(XPDI,";",2),XPDFILE)=XPDI,^(XPDFILE,0)=%
+"RTN","XPDTC",56,0)
+ .Q
+"RTN","XPDTC",57,0)
+ Q
+"RTN","XPDTC",58,0)
+QUES ;build from Install Questions multiple
+"RTN","XPDTC",59,0)
+ N I,J,K,X,%
+"RTN","XPDTC",60,0)
+ S X=""
+"RTN","XPDTC",61,0)
+ ;the "B" x-ref will give me the order of the questions
+"RTN","XPDTC",62,0)
+ F  S X=$O(^XPD(9.6,XPDA,"QUES","B",X)) Q:X=""  S I=$$QUES^XPDV(X) S:'I XPDERR=1 D:I
+"RTN","XPDTC",63,0)
+ .S J=0 F  S J=$O(^XPD(9.6,XPDA,"QUES",I,J)) Q:J=""  D
+"RTN","XPDTC",64,0)
+ ..;tranform J to DIR subscripts
+"RTN","XPDTC",65,0)
+ ..I $L(J)=1!(J="QQ") S ^XTMP("XPDT",XPDA,"QUES",X,$TR(J,"1ABQ","0AB?"))=^(J) Q  ;^(J) ref to ^XPD(9.6,XPDA,"QUES",I,J)
+"RTN","XPDTC",66,0)
+ ..;set the word processing fields into DIR("?",#) structure
+"RTN","XPDTC",67,0)
+ ..F %=1:1 Q:'$D(^XPD(9.6,XPDA,"QUES",I,J,%,0))  S ^XTMP("XPDT",XPDA,"QUES",X,$TR(J,"AQ10","A?"),%)=^(0)
+"RTN","XPDTC",68,0)
+ ;send the File questions
+"RTN","XPDTC",69,0)
+ S K=$G(^XPD(9.6,XPDA,"QDEF")) ;Developer Defaults for Questions
+"RTN","XPDTC",70,0)
+ F I=1:2 S X=$P($T(QUESTION+I),";;",2,99) Q:X=""  S Y=$P($T(QUESTION+I+1),";;",2) D
+"RTN","XPDTC",71,0)
+ .S ^XTMP("XPDT",XPDA,"QUES",$P(X,";"),0)=$P(X,";",2),^("A")=$P(X,";",3),^("B")=$S($L($P(K,U,I)):$P(K,U,I),1:$P(X,";",4)),^("??")=$P(X,";",5) S:Y]"" ^("M")=Y
+"RTN","XPDTC",72,0)
+ Q
+"RTN","XPDTC",73,0)
+INT ;build pre,post, & enviroment init routines
+"RTN","XPDTC",74,0)
+ N %,I,R,X,Z
+"RTN","XPDTC",75,0)
+ F I="PRE","INI","INIT" I $G(^XPD(9.6,XPDA,I))]"" S X=^(I) D
+"RTN","XPDTC",76,0)
+ .;remove parameters and seperate routine name from tag^routine
+"RTN","XPDTC",77,0)
+ .S ^XTMP("XPDT",XPDA,I)=X,X=$P(X,"("),R=$P(X,U,$L(X,U)) Q:$D(^("RTN",R))
+"RTN","XPDTC",78,0)
+ .I '$$RTN^XPDV(X,.Z) W !,"Routine ",X,Z S XPDERR=1 Q
+"RTN","XPDTC",79,0)
+ .S %=$$LOAD^XPDTA(R,"0^")
+"RTN","XPDTC",80,0)
+ Q
+"RTN","XPDTC",81,0)
+BLD ;build Build file, Package file and Order Parameter file
+"RTN","XPDTC",82,0)
+ N %,DIC,X,XPD,XPDI,XPDV,Y
+"RTN","XPDTC",83,0)
+ ;Update the 'Date Distributed' field
+"RTN","XPDTC",84,0)
+ S XPD(9.6,XPDA_",",.02)=$$DT^XLFDT()
+"RTN","XPDTC",85,0)
+ D FILE^DIE("","XPD") K XPD
+"RTN","XPDTC",86,0)
+ ;save version of kernel and fm
+"RTN","XPDTC",87,0)
+ S ^XTMP("XPDT",XPDA,"VER")=$$VERSION^XPDUTL("XU")_U_$$VERSION^XPDUTL("VA FILEMAN")
+"RTN","XPDTC",88,0)
+ S ^XTMP("XPDT",XPDA,"MBREQ")=$P($G(XPDT(XPDT)),U,4)
+"RTN","XPDTC",89,0)
+ M ^XTMP("XPDT",XPDA,"BLD",XPDA)=^XPD(9.6,XPDA)
+"RTN","XPDTC",90,0)
+ ;check national package file pointer
+"RTN","XPDTC",91,0)
+ S XPDI=$P(^XPD(9.6,XPDA,0),U,2)
+"RTN","XPDTC",92,0)
+ I XPDI="" W !,"No Package File Link" Q
+"RTN","XPDTC",93,0)
+ S $P(^XTMP("XPDT",XPDA,"BLD",XPDA,0),U,2)=$$PT^XPDTA("^DIC(9.4)",XPDI)
+"RTN","XPDTC",94,0)
+ ;quit if no pointer to package file
+"RTN","XPDTC",95,0)
+ I '$D(^DIC(9.4,XPDI)) W !,"Package File Link is corrupted" S XPDERR=1 Q
+"RTN","XPDTC",96,0)
+ ;update version multiple in package file,XPD=version^date distributed
+"RTN","XPDTC",97,0)
+ S XPD=$$VER^XPDUTL(XPDNM)_U_$P(^XTMP("XPDT",XPDA,"BLD",XPDA,0),U,4)
+"RTN","XPDTC",98,0)
+ ;XPD(1)=root of description field
+"RTN","XPDTC",99,0)
+ S:$D(^XTMP("XPDT",XPDA,"BLD",XPDA,1)) XPD(1)=$NA(^(1))
+"RTN","XPDTC",100,0)
+ S ^XTMP("XPDT",XPDA,"PKG",XPDI,0)=^DIC(9.4,XPDI,0),^XTMP("XPDT",XPDA,"PKG",XPDI,22,0)="^"_$P(^DD(9.4,22,0),U,2)_"^1^1"
+"RTN","XPDTC",101,0)
+ ;XPDNM'["*" is a version release
+"RTN","XPDTC",102,0)
+ I XPDNM'["*" D
+"RTN","XPDTC",103,0)
+ .S XPDV=$$PKGVER^XPDIP(XPDI,.XPD)
+"RTN","XPDTC",104,0)
+ .;Merge is used to set single nodes and merge multiples
+"RTN","XPDTC",105,0)
+ .F %=1,5,7,"DEV","VERSION" M ^XTMP("XPDT",XPDA,"PKG",XPDI,%)=^DIC(9.4,XPDI,%)
+"RTN","XPDTC",106,0)
+ .;XPDV=ien of Version Multiple
+"RTN","XPDTC",107,0)
+ .I $D(^DIC(9.4,XPDI,22,XPDV))'>9 W !!,"**Version multiple in Package file wasn't updated**",!! S XPDERR=1 Q
+"RTN","XPDTC",108,0)
+ .;get just the current version multiple and make it the first entry in version multiple
+"RTN","XPDTC",109,0)
+ .M ^XTMP("XPDT",XPDA,"PKG",XPDI,22,1)=^DIC(9.4,XPDI,22,XPDV)
+"RTN","XPDTC",110,0)
+ .;check if SEND PATCH HISTORY is NO, kill PAH
+"RTN","XPDTC",111,0)
+ .I $P(XPDT(XPDT),U,5) K ^XTMP("XPDT",XPDA,"PKG",XPDI,22,1,"PAH")
+"RTN","XPDTC",112,0)
+ ;this is a patch, %=version number, $P(XPD,U)=patch number
+"RTN","XPDTC",113,0)
+ E  D
+"RTN","XPDTC",114,0)
+ .S %=$P(XPD,U),$P(XPD,U)=$P(XPDNM,"*",3),XPDV=$$PKGPAT^XPDIP(XPDI,%,.XPD)
+"RTN","XPDTC",115,0)
+ .S ^XTMP("XPDT",XPDA,"PKG",XPDI,22,1,0)=^DIC(9.4,XPDI,22,+XPDV,0)
+"RTN","XPDTC",116,0)
+ .I $D(^DIC(9.4,XPDI,22,+XPDV,"PAH",+$P(XPDV,U,2)))'>9 W !!,"**Patch multiple in Package file wasn't updated**",!! S XPDERR=1 Q
+"RTN","XPDTC",117,0)
+ .M ^XTMP("XPDT",XPDA,"PKG",XPDI,22,1,"PAH",1)=^DIC(9.4,XPDI,22,+XPDV,"PAH",+$P(XPDV,U,2))
+"RTN","XPDTC",118,0)
+ .;if CURRENT VERSION was updated in $$PKGPAT, save to TG
+"RTN","XPDTC",119,0)
+ .I $P(XPDV,U,3) S ^XTMP("XPDT",XPDA,"PKG",XPDI,"VERSION")=$P(XPDV,U,3)
+"RTN","XPDTC",120,0)
+ ;save the version ien^patch ien on -1 node
+"RTN","XPDTC",121,0)
+ S ^XTMP("XPDT",XPDA,"PKG",XPDI,-1)="1^1"
+"RTN","XPDTC",122,0)
+ ;resolve Primary Help Frame (0;4)
+"RTN","XPDTC",123,0)
+ S %=+$P(^DIC(9.4,XPDI,0),U,4) S:% $P(^XTMP("XPDT",XPDA,"PKG",XPDI,0),U,4)=$$PT^XPDTA("^DIC(9.2)",%)
+"RTN","XPDTC",124,0)
+ Q
+"RTN","XPDTC",125,0)
+ ;
+"RTN","XPDTC",126,0)
+ACT(%) ;execute action
+"RTN","XPDTC",127,0)
+ ;user can count on DA,XPDFILE,XPDFL,XPDNM,XPDOLDA being around
+"RTN","XPDTC",128,0)
+ ;DA=ien in ^XTMP("XPDT",XPDA,"KRN",XPDFILE,DA)
+"RTN","XPDTC",129,0)
+ ;XPDOLDA=ien in ^XPD(9.6,XPDA,"KRN",XPDIFLE,"NM",XPDOLDA)
+"RTN","XPDTC",130,0)
+ N EACT,FACT,FGR,K0,Y0
+"RTN","XPDTC",131,0)
+ S:%'["^" %="^"_%
+"RTN","XPDTC",132,0)
+ D @% Q
+"RTN","XPDTC",133,0)
+ ;
+"RTN","XPDTC",134,0)
+ ;the following are the default questions for the INSTALL QUESTIONS
+"RTN","XPDTC",135,0)
+ ;in file 9.6, the format is:
+"RTN","XPDTC",136,0)
+ ;;field .01;field 1;field 2;field 4;field 7
+"RTN","XPDTC",137,0)
+ ;;field 10
+"RTN","XPDTC",138,0)
+QUESTION ;package install questions
+"RTN","XPDTC",139,0)
+ ;;XPF1;Y;Shall I write over your |FLAG| File;YES;^D REP^XPDH
+"RTN","XPDTC",140,0)
+ ;;D XPF1^XPDIQ
+"RTN","XPDTC",141,0)
+ ;;XPF2;Y;Want my data |FLAG| yours;YES;^D DTA^XPDH
+"RTN","XPDTC",142,0)
+ ;;D XPF2^XPDIQ
+"RTN","XPDTC",143,0)
+ ;;XPI1;YO;Want KIDS to INHIBIT LOGONs during the install;NO;^D INHIBIT^XPDH
+"RTN","XPDTC",144,0)
+ ;;D XPI1^XPDIQ
+"RTN","XPDTC",145,0)
+ ;;XPM1;PO^VA(200,:EM;Enter the Coordinator for Mail Group '|FLAG|';;^D MG^XPDH
+"RTN","XPDTC",146,0)
+ ;;D XPM1^XPDIQ
+"RTN","XPDTC",147,0)
+ ;;XPO1;Y;Want KIDS to Rebuild Menu Trees Upon Completion of Install;NO;^D MENU^XPDH
+"RTN","XPDTC",148,0)
+ ;;D XPO1^XPDIQ
+"RTN","XPDTC",149,0)
+ ;;XPZ1;Y;Want to DISABLE Scheduled Options, Menu Options, and Protocols;NO;^D OPT^XPDH
+"RTN","XPDTC",150,0)
+ ;;D XPZ1^XPDIQ
+"RTN","XPDTC",151,0)
+ ;;XPZ2;Y;Want to MOVE routines to other CPUs;NO;^D RTN^XPDH
+"RTN","XPDTC",152,0)
+ ;;D XPZ2^XPDIQ
+"RTN","XPDUTL")
+0^13^B24086795^B24049764
+"RTN","XPDUTL",1,0)
+XPDUTL ;SFISC/RSD - KIDS utilities ;10/15/2008
+"RTN","XPDUTL",2,0)
+ ;;8.0;KERNEL;**21,28,39,81,100,108,137,181,275,491,511,559,672**;Jul 10, 1995;Build 28
+"RTN","XPDUTL",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XPDUTL",4,0)
+ Q
+"RTN","XPDUTL",5,0)
+VERSION(X) ;Get current version from Package file, X=package name or
+"RTN","XPDUTL",6,0)
+ ;package namespace
+"RTN","XPDUTL",7,0)
+ N I
+"RTN","XPDUTL",8,0)
+ S I=$$LKPKG(X) Q:'I ""
+"RTN","XPDUTL",9,0)
+ Q $P($G(^DIC(9.4,+I,"VERSION")),"^")
+"RTN","XPDUTL",10,0)
+ ;
+"RTN","XPDUTL",11,0)
+VER(X) ;returns version number from Build file, X=build name
+"RTN","XPDUTL",12,0)
+ Q:X["*" $P(X,"*",2)
+"RTN","XPDUTL",13,0)
+ Q $P(X," ",$L(X," "))
+"RTN","XPDUTL",14,0)
+ ;
+"RTN","XPDUTL",15,0)
+STATUS(IEN) ;returns status from Install File, IEN=Install File IEN
+"RTN","XPDUTL",16,0)
+ I '$D(^XPD(9.7,IEN,0)) Q -1
+"RTN","XPDUTL",17,0)
+ Q $P(^XPD(9.7,IEN,0),U,9)
+"RTN","XPDUTL",18,0)
+ ;
+"RTN","XPDUTL",19,0)
+PKG(X) ;returns package name from Build file, X=build name
+"RTN","XPDUTL",20,0)
+ Q $S(X["*":$P(X,"*"),1:$P(X," ",1,$L(X," ")-1))
+"RTN","XPDUTL",21,0)
+ ;
+"RTN","XPDUTL",22,0)
+LAST(PKG,VER,REL) ;returns last patch applied for a Package, PATCH^DATE
+"RTN","XPDUTL",23,0)
+ ;PKG=package name, VER=version number, REL[optional]=1 if you want released patches only
+"RTN","XPDUTL",24,0)
+ ;Patch includes Seq # if Released
+"RTN","XPDUTL",25,0)
+ N PKGIEN,VERIEN,LATEST,PATCH,SUBIEN,Y
+"RTN","XPDUTL",26,0)
+ S PKGIEN=$$LKPKG($G(PKG)) Q:'PKGIEN -1
+"RTN","XPDUTL",27,0)
+ I $G(VER)="" S VER=$P($G(^DIC(9.4,PKGIEN,"VERSION")),"^") Q:'VER -1
+"RTN","XPDUTL",28,0)
+ S VERIEN=$O(^DIC(9.4,PKGIEN,22,"B",VER,"")) Q:'VERIEN -1
+"RTN","XPDUTL",29,0)
+ S LATEST=-1,PATCH=-1,SUBIEN=0
+"RTN","XPDUTL",30,0)
+ F  S SUBIEN=$O(^DIC(9.4,PKGIEN,22,VERIEN,"PAH",SUBIEN)) Q:SUBIEN'>0  S Y=$G(^(SUBIEN,0)) D:$P(Y,U,2)>LATEST
+"RTN","XPDUTL",31,0)
+ . I $G(REL),$P(Y,U)'["SEQ #" Q  ;released only, must contain SEQ
+"RTN","XPDUTL",32,0)
+ . S LATEST=$P(Y,U,2),PATCH=$P(Y,U)
+"RTN","XPDUTL",33,0)
+ Q PATCH_U_LATEST
+"RTN","XPDUTL",34,0)
+ ;
+"RTN","XPDUTL",35,0)
+PATCH(X) ;return 1 if patch X was installed, X=aaaa*nn.nn*nnnn ; p672 change 1.3N to 1.4N
+"RTN","XPDUTL",36,0)
+ Q:X'?1.4UN1"*"1.2N1"."1.2N.1(1"V",1"T").2N1"*"1.4N 0
+"RTN","XPDUTL",37,0)
+ N %,I,J
+"RTN","XPDUTL",38,0)
+ S I=$$LKPKG($P(X,"*")) Q:'I 0
+"RTN","XPDUTL",39,0)
+ S J=$O(^DIC(9.4,I,22,"B",$P(X,"*",2),0)),X=$P(X,"*",3) Q:'J 0
+"RTN","XPDUTL",40,0)
+ ;check if patch is just a number
+"RTN","XPDUTL",41,0)
+ Q:$O(^DIC(9.4,I,22,J,"PAH","B",X,0)) 1
+"RTN","XPDUTL",42,0)
+ S %=$O(^DIC(9.4,I,22,J,"PAH","B",X_" SEQ"))
+"RTN","XPDUTL",43,0)
+ Q $S(%="":0,1:(X=+%))
+"RTN","XPDUTL",44,0)
+ ;
+"RTN","XPDUTL",45,0)
+INSTALDT(INSTALL,RESULT) ;returns number of installs, 0 if not installed or doesn't exist
+"RTN","XPDUTL",46,0)
+ ;input: INSTALL=required, Install name; RESULT=required, passed by reference
+"RTN","XPDUTL",47,0)
+ ;output: RESULT=number in RESULT array; RESULT(FM date/time)=TEST# ^ SEQ#
+"RTN","XPDUTL",48,0)
+ N CNT,DATE,IEN
+"RTN","XPDUTL",49,0)
+ K RESULT
+"RTN","XPDUTL",50,0)
+ S (IEN,CNT,RESULT)=0
+"RTN","XPDUTL",51,0)
+ I $G(INSTALL)="" Q 0
+"RTN","XPDUTL",52,0)
+ F  S IEN=$O(^XPD(9.7,"B",INSTALL,IEN)) Q:'IEN  D
+"RTN","XPDUTL",53,0)
+ .S DATE=$P($G(^XPD(9.7,IEN,1)),U,3) Q:'DATE
+"RTN","XPDUTL",54,0)
+ .S RESULT(DATE)=$G(^XPD(9.7,IEN,6)),CNT=CNT+1
+"RTN","XPDUTL",55,0)
+ S RESULT=CNT
+"RTN","XPDUTL",56,0)
+ Q CNT
+"RTN","XPDUTL",57,0)
+ ;
+"RTN","XPDUTL",58,0)
+NEWCP(XPD,XPDC,XPDP) ;create new check point, returns 0=error or ien
+"RTN","XPDUTL",59,0)
+ ;XPD=name, XPDC=call back, XPDP=parameters
+"RTN","XPDUTL",60,0)
+ Q:$G(XPD)="" 0
+"RTN","XPDUTL",61,0)
+ N %,XPDI,XPDJ,XPDF,XPDY
+"RTN","XPDUTL",62,0)
+ ;XPDCP="INI"=Pre-init, "INIT"=Post-init
+"RTN","XPDUTL",63,0)
+ S XPDI=$S(XPDCP="INIT":9.716,1:9.713)
+"RTN","XPDUTL",64,0)
+ S %=$$FIND1^DIC(XPDI,","_XPDA_",","X",XPD) Q:% %
+"RTN","XPDUTL",65,0)
+ S XPDF="+1,"_XPDA_",",XPDJ(XPDI,XPDF,.01)=XPD
+"RTN","XPDUTL",66,0)
+ S:$D(XPDC) XPDJ(XPDI,XPDF,2)=XPDC
+"RTN","XPDUTL",67,0)
+ S:$D(XPDP) XPDJ(XPDI,XPDF,3)=XPDP
+"RTN","XPDUTL",68,0)
+ D UPDATE^DIE("","XPDJ","XPDY")
+"RTN","XPDUTL",69,0)
+ Q $G(XPDY(1))
+"RTN","XPDUTL",70,0)
+ ;
+"RTN","XPDUTL",71,0)
+UPCP(XPD,XPDP) ;update check point, returns 0=error or ien
+"RTN","XPDUTL",72,0)
+ ;XPD=name, XPDP=parameters
+"RTN","XPDUTL",73,0)
+ N XPDI,XPDJ,XPDF,XPDY
+"RTN","XPDUTL",74,0)
+ ;XPDCP="INI"=Pre-init, "INIT"=Post-init
+"RTN","XPDUTL",75,0)
+ S XPDI=$S(XPDCP="INIT":9.716,1:9.713),XPDY=$$DICCP($G(XPD))
+"RTN","XPDUTL",76,0)
+ Q:'XPDY 0
+"RTN","XPDUTL",77,0)
+ S XPDF=XPDY_","_XPDA_","
+"RTN","XPDUTL",78,0)
+ S:$D(XPDP) XPDJ(XPDI,XPDF,3)=XPDP
+"RTN","XPDUTL",79,0)
+ D FILE^DIE("","XPDJ")
+"RTN","XPDUTL",80,0)
+ Q XPDY
+"RTN","XPDUTL",81,0)
+ ;
+"RTN","XPDUTL",82,0)
+COMCP(XPD) ;complete check point, returns 0=error or date/time
+"RTN","XPDUTL",83,0)
+ ;XPD=name
+"RTN","XPDUTL",84,0)
+ N XPDD,XPDI,XPDJ,XPDY
+"RTN","XPDUTL",85,0)
+ S XPDI=$S(XPDCP="INIT":9.716,1:9.713),XPDY=$$DICCP($G(XPD))
+"RTN","XPDUTL",86,0)
+ Q:'XPDY 0
+"RTN","XPDUTL",87,0)
+ S XPDD=$$NOW^XLFDT,XPDJ(XPDI,XPDY_","_XPDA_",",1)=XPDD
+"RTN","XPDUTL",88,0)
+ D FILE^DIE("","XPDJ")
+"RTN","XPDUTL",89,0)
+ Q XPDD
+"RTN","XPDUTL",90,0)
+ ;
+"RTN","XPDUTL",91,0)
+VERCP(XPD) ;verify check point, returns 1=completed, 0=not
+"RTN","XPDUTL",92,0)
+ ;-1=doesn't exist
+"RTN","XPDUTL",93,0)
+ ;XPD=name
+"RTN","XPDUTL",94,0)
+ N XPDI,XPDY
+"RTN","XPDUTL",95,0)
+ S XPDI=$S(XPDCP="INIT":9.716,1:9.713),XPDY=$$DICCP($G(XPD))
+"RTN","XPDUTL",96,0)
+ Q:'XPDY -1
+"RTN","XPDUTL",97,0)
+ Q ''$$GET1^DIQ(XPDI,XPDY_","_XPDA_",",1,"I")
+"RTN","XPDUTL",98,0)
+ ;
+"RTN","XPDUTL",99,0)
+PARCP(XPD,XPDF) ;returns parameters of check point
+"RTN","XPDUTL",100,0)
+ ;XPD=name, XPDF="PRE"
+"RTN","XPDUTL",101,0)
+ N XPDI,XPDY
+"RTN","XPDUTL",102,0)
+ I $G(XPDF)="PRE" N XPDCP S XPDCP="INI"
+"RTN","XPDUTL",103,0)
+ S XPDI=$S(XPDCP="INIT":9.716,1:9.713),XPDY=$$DICCP($G(XPD))
+"RTN","XPDUTL",104,0)
+ Q:'XPDY 0
+"RTN","XPDUTL",105,0)
+ Q $$GET1^DIQ(XPDI,XPDY_","_XPDA_",",3,"I")
+"RTN","XPDUTL",106,0)
+ ;
+"RTN","XPDUTL",107,0)
+CURCP(XPDF) ;returns current check point
+"RTN","XPDUTL",108,0)
+ ;XPDF flag - 0=externel, 1=internal
+"RTN","XPDUTL",109,0)
+ Q $S($G(XPDF):XPDCHECK,1:XPDCHECK(0))
+"RTN","XPDUTL",110,0)
+ ;
+"RTN","XPDUTL",111,0)
+WP(X) ;X=global ref
+"RTN","XPDUTL",112,0)
+ N %
+"RTN","XPDUTL",113,0)
+ Q:'$D(@X)
+"RTN","XPDUTL",114,0)
+ F %=1:1 Q:'$D(@X@(%))  W !,@X@(%)
+"RTN","XPDUTL",115,0)
+ Q:'$G(XPDA)  D WP^DIE(9.7,XPDA_",",20,"A",X)
+"RTN","XPDUTL",116,0)
+ Q
+"RTN","XPDUTL",117,0)
+MES(X) ;record message, X=message or an array passed by reference
+"RTN","XPDUTL",118,0)
+ N %
+"RTN","XPDUTL",119,0)
+ I $D(X)#2 S %=X K X S X(1)=%
+"RTN","XPDUTL",120,0)
+ ;write message
+"RTN","XPDUTL",121,0)
+ F %=1:1 Q:'$D(X(%))  W !,X(%)
+"RTN","XPDUTL",122,0)
+ Q:'$G(XPDA)  D WP^DIE(9.7,XPDA_",",20,"A","X")
+"RTN","XPDUTL",123,0)
+ Q
+"RTN","XPDUTL",124,0)
+BMES(X) ;add blank line before message
+"RTN","XPDUTL",125,0)
+ N %
+"RTN","XPDUTL",126,0)
+ I $D(X)#2 S %=X K X S X(1)=" ",X(2)=%
+"RTN","XPDUTL",127,0)
+ D MES(.X)
+"RTN","XPDUTL",128,0)
+ Q
+"RTN","XPDUTL",129,0)
+RTNUP(X,Y) ;update routine action, X=routine, Y=action
+"RTN","XPDUTL",130,0)
+ ;actions:  1=delete, 2=skip
+"RTN","XPDUTL",131,0)
+ N %
+"RTN","XPDUTL",132,0)
+ ;set action to Y
+"RTN","XPDUTL",133,0)
+ Q:'$G(Y)!'$D(^XTMP("XPDI",$G(XPDA),"RTN",X)) 0 S $P(^(X),U)=+Y
+"RTN","XPDUTL",134,0)
+ Q 1
+"RTN","XPDUTL",135,0)
+ ;get Build ien
+"RTN","XPDUTL",136,0)
+ S Y=$O(^XTMP("XPDI",XPDA,"BLD",0))
+"RTN","XPDUTL",137,0)
+ ;remove checksum when updating action, since action can only be
+"RTN","XPDUTL",138,0)
+ ;delete or skip, not sure if we want to do this
+"RTN","XPDUTL",139,0)
+ S:$P(%,U,2) $P(^XTMP("XPDI",XPDA,"BLD",Y,"KRN",9.8,"NM",$P(%,U,2),0),U,4)=""
+"RTN","XPDUTL",140,0)
+ Q 1
+"RTN","XPDUTL",141,0)
+ ;
+"RTN","XPDUTL",142,0)
+RTNLOG(X) ;Enter/Update routine in the Routine File
+"RTN","XPDUTL",143,0)
+ N Y,FDA,IEN
+"RTN","XPDUTL",144,0)
+ S Y=$O(^DIC(9.8,"B",X,0))
+"RTN","XPDUTL",145,0)
+ I Y'>0 S IEN="?+1,",FDA(9.8,IEN,1)="R"
+"RTN","XPDUTL",146,0)
+ I Y>0 S IEN=(+Y)_","
+"RTN","XPDUTL",147,0)
+ S FDA(9.8,IEN,.01)=X,FDA(9.8,IEN,7.4)=$$NOW^XLFDT
+"RTN","XPDUTL",148,0)
+ D UPDATE^DIE("","FDA","IEN")
+"RTN","XPDUTL",149,0)
+ Q
+"RTN","XPDUTL",150,0)
+ ;
+"RTN","XPDUTL",151,0)
+DICCP(X) ;lookup check point, returns ien or 0
+"RTN","XPDUTL",152,0)
+ Q:$G(X)="" 0
+"RTN","XPDUTL",153,0)
+ ;if they pass ien, fail if can't find
+"RTN","XPDUTL",154,0)
+ I X=+X S Y=X Q:'$D(^XPD(9.7,XPDA,XPDCP,Y,0)) 0
+"RTN","XPDUTL",155,0)
+ E  S Y=$$FIND1^DIC(XPDI,","_XPDA_",","X",X)
+"RTN","XPDUTL",156,0)
+ Q Y
+"RTN","XPDUTL",157,0)
+ ;
+"RTN","XPDUTL",158,0)
+PRODE(XPDN,XPD) ;enable/disable protocols, return 1 for success
+"RTN","XPDUTL",159,0)
+ ;XPDN=protocol name, XPD=1-enable, 0-disable
+"RTN","XPDUTL",160,0)
+ Q:$G(XPDN)="" 0
+"RTN","XPDUTL",161,0)
+ S XPD=+$G(XPD)
+"RTN","XPDUTL",162,0)
+ D KIDS^XQOO1($P(XPDSET,U,2),101,XPDN,.XPD)
+"RTN","XPDUTL",163,0)
+ Q $S(XPD<0:0,1:1)
+"RTN","XPDUTL",164,0)
+ ;
+"RTN","XPDUTL",165,0)
+OPTDE(XPDN,XPD) ;enable/disable options, return 1 for success
+"RTN","XPDUTL",166,0)
+ ;XPDN=protocol name, XPD=1-enable, 0-disable
+"RTN","XPDUTL",167,0)
+ Q:$G(XPDN)="" 0
+"RTN","XPDUTL",168,0)
+ S XPD=+$G(XPD)
+"RTN","XPDUTL",169,0)
+ D KIDS^XQOO1($P(XPDSET,U,2),19,XPDN,.XPD)
+"RTN","XPDUTL",170,0)
+ Q $S(XPD<0:0,1:1)
+"RTN","XPDUTL",171,0)
+ ;
+"RTN","XPDUTL",172,0)
+BUILD(XPDN,XPD) ;check if a build exists, return 1 for success
+"RTN","XPDUTL",173,0)
+ ;XPDN=build name, XPD=1-exist, 0-been removed
+"RTN","XPDUTL",174,0)
+ S XPD=$D(XPDT("NM",XPDN))
+"RTN","XPDUTL",175,0)
+ Q XPD
+"RTN","XPDUTL",176,0)
+ ;
+"RTN","XPDUTL",177,0)
+MAILGRP(X) ;Return mail group for package, X=package name or namespace
+"RTN","XPDUTL",178,0)
+ N XD,DIC,DR,DA,DIQ
+"RTN","XPDUTL",179,0)
+ S DA=$$LKPKG(X) Q:'DA ""
+"RTN","XPDUTL",180,0)
+ S DIC="^DIC(9.4,",DR=1938,DIQ="XD" D EN^DIQ1
+"RTN","XPDUTL",181,0)
+ Q $S($G(XD(9.4,DA,1938))="":"",1:"G."_XD(9.4,DA,1938))
+"RTN","XPDUTL",182,0)
+ ;
+"RTN","XPDUTL",183,0)
+LKPKG(X) ;Return Package ien,  X=package name or namespace
+"RTN","XPDUTL",184,0)
+ Q:$G(X)="" 0
+"RTN","XPDUTL",185,0)
+ N DA
+"RTN","XPDUTL",186,0)
+ I $L(X)<5 D  Q:DA +DA
+"RTN","XPDUTL",187,0)
+ .S DA=$O(^DIC(9.4,"C",X,0))
+"RTN","XPDUTL",188,0)
+ .S:'DA DA=$O(^DIC(9.4,"C2",X,0))
+"RTN","XPDUTL",189,0)
+ I $L(X)>3 S DA=$O(^DIC(9.4,"B",X,0))
+"RTN","XPDUTL",190,0)
+ Q +DA
+"RTN","XQ1")
+0^18^B38427673^B38155212
+"RTN","XQ1",1,0)
+XQ1 ; SEA/MJM - DRIVER FOR MENUMAN (PART 2) ;08/28/08  13:20
+"RTN","XQ1",2,0)
+ ;;8.0;KERNEL;**1,15,59,67,46,151,170,242,446,672**;Jul 10, 1995;Build 28
+"RTN","XQ1",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XQ1",4,0)
+ S DIC=19,DIC(0)="AEQM" D ^DIC Q:Y<0  S (XQDIC,XQY)=+Y K DIC,XQUR,Y,^VA(200,DUZ,202.1)
+"RTN","XQ1",5,0)
+ D INIT^XQ12
+"RTN","XQ1",6,0)
+ G M^XQ
+"RTN","XQ1",7,0)
+ ;
+"RTN","XQ1",8,0)
+KILL K D,D0,D1,DA,DI,DIC,DIE,DIR,DIS,DIASKHD,DIPCRIT,DISUPNO,DPP,DR,FLDS,Q,XQI,XQV,XQW,XQZ
+"RTN","XQ1",9,0)
+ D CLEAN^DILF
+"RTN","XQ1",10,0)
+ ;
+"RTN","XQ1",11,0)
+OUT ;Exit point for all option types
+"RTN","XQ1",12,0)
+ S U="^"
+"RTN","XQ1",13,0)
+ I $D(XQXFLG("ZEBRA")) L ^XWB("SESSION",XQXFLG("ZEBRA")):15 ;Clear by setting new lock
+"RTN","XQ1",14,0)
+ E  L  ;Clear the lock table
+"RTN","XQ1",15,0)
+ ;
+"RTN","XQ1",16,0)
+ I $D(ZTQUEUED),'$D(XQUIT) D
+"RTN","XQ1",17,0)
+ .N XQF
+"RTN","XQ1",18,0)
+ .S XQF=$S('$D(^DIC(19,XQY,15)):0,'$L(^(15)):0,1:1) X:XQF ^(15)
+"RTN","XQ1",19,0)
+ .Q
+"RTN","XQ1",20,0)
+ Q:$D(ZTQUEUED)  ;Quit here if it's a Taskman job
+"RTN","XQ1",21,0)
+ ;
+"RTN","XQ1",22,0)
+ I '$D(DT)!('$D(DTIME))!('$D(DUZ))!('$D(DUZ(0)))!('$D(DUZ("AG")))!('$D(DUZ("AUTO"))) D DVARS^XQ12
+"RTN","XQ1",23,0)
+ I $D(DUZ("AUTO")),DUZ("AUTO"),$D(XQY),$D(^DIC(19,+XQY,0))#2,$P(^(0),"^",11)["y" W !!,*7,"Press RETURN to continue..." R %:DTIME
+"RTN","XQ1",24,0)
+ I $D(^XUTL("XQ",$J,"RBX")) G RBX^XQ73
+"RTN","XQ1",25,0)
+ I $D(^XUTL("XQ",$J,"T")) I ^("T")<0 S ^("T")=$S($D(^XUTL("XQ",$J,1)):1,1:0)
+"RTN","XQ1",26,0)
+ I $D(^XUTL("XQ",$J,"T")) S XQY=+^(^("T")),XQT="" S:$D(^DIC(19,+XQY,0)) XQT=$P(^(0),U,4) I '$D(XQUIT),("LOQX"'[XQT),$D(^DIC(19,XQY,15)),$L(^(15)) X ^(15) ;W "  ==> OUT^XQ1"
+"RTN","XQ1",27,0)
+ Q:'$D(^XUTL("XQ",$J,"T"))
+"RTN","XQ1",28,0)
+ I $D(^XUTL("XQ",$J,"T")) S XQTT=$S($D(XQUIT):^XUTL("XQ",$J,"T"),1:^XUTL("XQ",$J,"T")-1) K XQUIT
+"RTN","XQ1",29,0)
+ I XQTT'<1 S ^XUTL("XQ",$J,"T")=XQTT,XQY=^(XQTT),XQY0=$P(XQY,U,2,999),XQPSM=$P(XQY,U,1),XQY=+XQPSM,XQPSM=$P(XQPSM,XQY,2,99),XQABOLD=1
+"RTN","XQ1",30,0)
+ I XQTT=0 S XQY=-1
+"RTN","XQ1",31,0)
+ I $P(XQY0,U,4)="M" S XQAA=$P(XQY0,U,2) I $P(XQY0,U,17),$D(^DIC(19,+XQY,26)),$L(^(26)) X ^(26) ;W "  ==> OUT^XQ1"
+"RTN","XQ1",32,0)
+ K %,X,XQDICNEW,XQF,XQCO,XQEA,XQFLG,XQI,XQJ,XQJS,XQK,XQLOK,XQNOPE,XQOK,XQTT,XQX,XQZ,Y,Z
+"RTN","XQ1",33,0)
+ G M1^XQ
+"RTN","XQ1",34,0)
+ ;
+"RTN","XQ1",35,0)
+A ;ACTION type option entry point
+"RTN","XQ1",36,0)
+ X:$D(^DIC(19,+XQY,20)) ^(20) ;W "  ==> A^XQ1"
+"RTN","XQ1",37,0)
+ I $D(XQUIT) S XQUIT=1 D ^XQUIT I $D(XQUIT) K XQUIT G OUT
+"RTN","XQ1",38,0)
+ I $P(XQY0,U,17),$D(^DIC(19,XQY,26)),$L(^(26)) X ^(26) ;W "  ==> A^XQ1"
+"RTN","XQ1",39,0)
+ G OUT
+"RTN","XQ1",40,0)
+ ;
+"RTN","XQ1",41,0)
+C ;ScreenMan type options
+"RTN","XQ1",42,0)
+ D DIC G:DA=-1 KILL S XQZ="DR,DDSFILE,DDSFILE(1)",XQW=39 D SET
+"RTN","XQ1",43,0)
+ S DDSPAGE=$P($G(^DIC(19,+XQY,43)),U) K:DDSPAGE="" DDSPAGE
+"RTN","XQ1",44,0)
+ S DDSPARM=$P($G(^DIC(19,+XQY,43)),U,2) K:DDSPARM="" DDSPARM
+"RTN","XQ1",45,0)
+ I DDSFILE["(",DDSFILE'[U S DDSFILE=U_DDSFILE
+"RTN","XQ1",46,0)
+ I $D(DDSFILE(1)),DDSFILE(1)["(",DDSFILE(1)'[U S DDSFILE(1)=U_DDSFILE(1)
+"RTN","XQ1",47,0)
+ D ^DDS K DDSFILE G C
+"RTN","XQ1",48,0)
+ ;
+"RTN","XQ1",49,0)
+P ;PRINT type option
+"RTN","XQ1",50,0)
+ S XQZ="DIC,PG,L,FLDS,BY,FR,TO,DHD,DCOPIES,DIS(0),IOP,DHIT,DIOBEG,DIOEND",XQW=59 D SET
+"RTN","XQ1",51,0)
+ I $D(DIS(0))#2 F XQI=1:1:3 Q:'$D(^DIC(19,+XQY,69+(XQI/10)))  Q:^(69+(XQI/10))=""  S DIS(XQI)=^(69+(XQI/10))
+"RTN","XQ1",52,0)
+ S:$D(XQIOP) IOP=XQIOP
+"RTN","XQ1",53,0)
+ S XQI=$G(^DIC(19,XQY,79)) S:XQI>0 DIASKHD="" S:$P(XQI,U,2) DISUPNO=1 S:$P(XQI,U,3) DIPCRIT=1
+"RTN","XQ1",54,0)
+ D D1,EN1^DIP K IOP,DIOBEG,DIS,DP G OUT
+"RTN","XQ1",55,0)
+ ;
+"RTN","XQ1",56,0)
+I ;INQUIRE type option
+"RTN","XQ1",57,0)
+I1 D DIC G KILL:DA=-1 S DI=DIC,XQZ="DIC,DR,DIQ(0)",XQW=79 D SET,D1 S:$D(DIC)[0 DIC=DI
+"RTN","XQ1",58,0)
+ I $D(^DIC(19,+XQY,63)),$L(^(63)) S FLDS=^(63)
+"RTN","XQ1",59,0)
+ E  S FLDS="[CAPTIONED]"
+"RTN","XQ1",60,0)
+ S:$G(DIQ(0))="B" DIQ(0)="CR" ;p672
+"RTN","XQ1",61,0)
+ I $G(^DIC(19,+XQY,83))["Y" S IOP="HOME"
+"RTN","XQ1",62,0)
+I2 ;
+"RTN","XQ1",63,0)
+ W ! S XQZ="DHD",XQW=66 D SET K ^UTILITY($J),^(U,$J) S ^($J,1,DA)="",@("L=+$P("_DI_"0),U,2)"),DPP(1)=L_"^^^@",L=0,C=",",Q="""",DPP=1,DPP(1,"IX")="^UTILITY(U,$J,"_DI_"^2" D N^DIP1 S Y=XQY G I1
+"RTN","XQ1",64,0)
+ ;
+"RTN","XQ1",65,0)
+E ;EDIT type option entry point
+"RTN","XQ1",66,0)
+E1 D DIC G KILL:DA=-1 K DIE,DIC S XQZ="DIE,DR",XQW=49 D SET S XQZ="DIE(""W"")",XQW=53 D SET
+"RTN","XQ1",67,0)
+ I $D(^DIC(19,XQY,53)),$L(^(53)) S %=^(53),DIE("NO^")=$S(%="N":"",1:%)
+"RTN","XQ1",68,0)
+ ;S:DIE["(" DIE=U_DIE
+"RTN","XQ1",69,0)
+ ;
+"RTN","XQ1",70,0)
+ ;DIE does not lock so we do it here
+"RTN","XQ1",71,0)
+ ;
+"RTN","XQ1",72,0)
+ S XQLOK="",XQNOPE=0
+"RTN","XQ1",73,0)
+ I DIE["(" D
+"RTN","XQ1",74,0)
+ .S DIE=U_DIE
+"RTN","XQ1",75,0)
+ .S XQLOK=DIE_DA_")" L +@XQLOK:2
+"RTN","XQ1",76,0)
+ .I '$T S XQNOPE=1 W !,"Someone else is editing this data.  Try later."
+"RTN","XQ1",77,0)
+ .Q
+"RTN","XQ1",78,0)
+ ;
+"RTN","XQ1",79,0)
+ I DIE=+DIE D
+"RTN","XQ1",80,0)
+ .N %
+"RTN","XQ1",81,0)
+ .S %=$$ROOT^DILFD(DIE)
+"RTN","XQ1",82,0)
+ .I %'="" S XQLOK=%_DA_")" L +@XQLOK:2
+"RTN","XQ1",83,0)
+ .I '$T S XQNOPE=1 W !,"Someone else is editing this data.  Try later."
+"RTN","XQ1",84,0)
+ .Q
+"RTN","XQ1",85,0)
+ ;
+"RTN","XQ1",86,0)
+ G:XQNOPE E1  ;Node is being edited right now, skip DIE
+"RTN","XQ1",87,0)
+ D ^DIE S Y=XQY
+"RTN","XQ1",88,0)
+ I XQLOK'="" L -@XQLOK
+"RTN","XQ1",89,0)
+ G E1
+"RTN","XQ1",90,0)
+ ;
+"RTN","XQ1",91,0)
+ ;
+"RTN","XQ1",92,0)
+DIC ;Get FileMan parameters from Option File and do look up
+"RTN","XQ1",93,0)
+ W ! K DIC S XQZ="DIC,DIC(0),DIC(""A""),DIC(""B""),DIC(""S""),DIC(""W""),D",XQW=29 D SET,D1
+"RTN","XQ1",94,0)
+ I '$D(D) D ^DIC
+"RTN","XQ1",95,0)
+ I $D(D) S:D="" D="B" D IX^DIC
+"RTN","XQ1",96,0)
+ I $D(Y),Y>0,$P(Y,U,3) S XQDICNEW=Y
+"RTN","XQ1",97,0)
+ S DA=+Y,Y=XQY
+"RTN","XQ1",98,0)
+ Q
+"RTN","XQ1",99,0)
+ ;
+"RTN","XQ1",100,0)
+D1 S:DIC["(" DIC=U_DIC Q
+"RTN","XQ1",101,0)
+ ;
+"RTN","XQ1",102,0)
+SET F XQI=1:1 S XQV=$P(XQZ,",",XQI) Q:XQV=""  K @XQV I $D(^DIC(19,+XQY,XQW+XQI)),^(XQW+XQI)]"" S @XQV=^(XQW+XQI)
+"RTN","XQ1",103,0)
+ I $D(DIC("A")),DIC("A")]"" S DIC("A")=DIC("A")_" "
+"RTN","XQ1",104,0)
+ K XQI,J
+"RTN","XQ1",105,0)
+ Q
+"RTN","XQ1",106,0)
+ ;
+"RTN","XQ1",107,0)
+R ;RUN ROUTINE type option entry point
+"RTN","XQ1",108,0)
+ G:'$D(^DIC(19,XQY,25)) OUT:$D(ZTQUEUED),M1^XQ S XQZ=^(25) G:'$L(XQZ) M1^XQ S:XQZ'[U XQZ=U_XQZ I XQZ["[" D DO^%XUCI G OUT
+"RTN","XQ1",109,0)
+ D @XQZ G OUT
+"RTN","XQ1",110,0)
+ ;
+"RTN","XQ1",111,0)
+W ;Window type option entry point
+"RTN","XQ1",112,0)
+ S XQOK=1
+"RTN","XQ1",113,0)
+ I $D(^DIC(19,XQY,25)),$L(^(25)) D  G OUT ;Routine type
+"RTN","XQ1",114,0)
+ .S XQZ=^DIC(19,XQY,25)
+"RTN","XQ1",115,0)
+ .S:XQZ'[U XQZ=U_XQZ
+"RTN","XQ1",116,0)
+ .I XQZ["[" D DO^%XUCI Q
+"RTN","XQ1",117,0)
+ .D @XQZ
+"RTN","XQ1",118,0)
+ .Q
+"RTN","XQ1",119,0)
+ ;
+"RTN","XQ1",120,0)
+ ;I $D(^DIC(19,XQY,24)),$L(^(24)) D  G:XQOK OUT ;Pointer type
+"RTN","XQ1",121,0)
+ ;.S XQZ=^DIC(19,XQY,24)
+"RTN","XQ1",122,0)
+ ;.S XQZ=$P($G(^XTV(8995,XQZ,0)),U) I XQZ="" S XQOK=0 Q
+"RTN","XQ1",123,0)
+ ;.D PREP^XG
+"RTN","XQ1",124,0)
+ ;.S XQWIN=$$NEXTNM^XGCLOAD("XQWIN")
+"RTN","XQ1",125,0)
+ ;.D GET^XGCLOAD(XQZ,XQWIN,"^TMP($J)")
+"RTN","XQ1",126,0)
+ ;.D GET^XGCLOAD(XQZ,$NA(^TMP($J,XQWIN)))
+"RTN","XQ1",127,0)
+ ;.D M^XG(XQWIN,$NA(^TMP($J,XQWIN)))
+"RTN","XQ1",128,0)
+ ;.D ESTA^XG() ;Send it off to window land
+"RTN","XQ1",129,0)
+ ;.;
+"RTN","XQ1",130,0)
+ ;.D K^XG(XQWIN) ;Return here after the ESTOP
+"RTN","XQ1",131,0)
+ ;.;I $D(^%ZOSF("OS")),^%ZOSF("OS")["MSM" ZSTOP
+"RTN","XQ1",132,0)
+ ;.Q
+"RTN","XQ1",133,0)
+ ;
+"RTN","XQ1",134,0)
+ G M1^XQ ;Window failed
+"RTN","XQ1",135,0)
+ ;
+"RTN","XQ1",136,0)
+Z ;Window suite option
+"RTN","XQ1",137,0)
+ G EN^XQSUITE
+"RTN","XQ1",138,0)
+ ;
+"RTN","XQ1",139,0)
+S ;Server-type option pseudo entry-point can't be invoked from Meun System
+"RTN","XQ1",140,0)
+ G OUT
+"RTN","XQ1",141,0)
+ ;
+"RTN","XQ1",142,0)
+B ;Client/Server option can't be run from menu system
+"RTN","XQ1",143,0)
+ G OUT
+"RTN","XQ1",144,0)
+ ;
+"RTN","XQ1",145,0)
+L ;OE/RR Limited option
+"RTN","XQ1",146,0)
+O ;OE/RR Protocol (orderables) type option entry point
+"RTN","XQ1",147,0)
+X ;OE/RR Extended Action type option (Subset of Protocol type)
+"RTN","XQ1",148,0)
+Q ;OE/RR Protocol Menu type option entry point
+"RTN","XQ1",149,0)
+ S XQOR=+XQY,XQOR(1)=XQT D XQ^XQOR K XQOR G OUT
+"RTN","XQ1",150,0)
+ ;
+"RTN","XQ1",151,0)
+ZTSK ;Task Manager entry point
+"RTN","XQ1",152,0)
+ S U="^" G:$G(XQSCH)'>0 ZTSK2 ;No reschedule
+"RTN","XQ1",153,0)
+ S %=$$S^%ZTLOAD("Reschedule Task")
+"RTN","XQ1",154,0)
+ S XQ=$G(^DIC(19.2,XQSCH,0)),XQY=+XQ Q:XQY'>0
+"RTN","XQ1",155,0)
+ K ZTQPARAM ;Build params from schedule in case we delete it.
+"RTN","XQ1",156,0)
+ I $D(^DIC(19.2,XQSCH,3)),$L(^(3)) S ZTQPARAM=^(3)
+"RTN","XQ1",157,0)
+ I $D(^DIC(19.2,XQSCH,2)) D  ;Build other symbols
+"RTN","XQ1",158,0)
+ . N X1,X2 S X2=XQSCH N XQSCH,XQY,XQ
+"RTN","XQ1",159,0)
+ . F X1=0:0 S X1=$O(^DIC(19.2,X2,2,X1)) Q:X1'>0  S X=^(X1,0),@($P(X,U)_"="_$P(X,U,2))
+"RTN","XQ1",160,0)
+ . Q
+"RTN","XQ1",161,0)
+ ;
+"RTN","XQ1",162,0)
+ S X=$P($G(^DIC(19.2,XQSCH,1.1)),U) I X>0 D DUZ^XUP(X) ;User to run job ;p446
+"RTN","XQ1",163,0)
+REQ D  ;Set the user and Requeue
+"RTN","XQ1",164,0)
+ . N DA,DIE,DR,X,X1,X2
+"RTN","XQ1",165,0)
+ . S X1=$P(XQ,U,2),X2=$P(XQ,U,6) ;Get params for new schedule
+"RTN","XQ1",166,0)
+ . S DA=XQSCH,DIE="^DIC(19.2,",DR=$S((X2="")&($P(XQ,U,9)=""):".01///@",X2="":"2///@",1:"2////"_$$SCH^XLFDT(X2,+X1,1))
+"RTN","XQ1",167,0)
+ . L +^%ZTSK(ZTSK,0):15 D ^DIE L -^%ZTSK(ZTSK,0) ;File new schedule
+"RTN","XQ1",168,0)
+ . Q
+"RTN","XQ1",169,0)
+ ;ZTREQ is set by TM.
+"RTN","XQ1",170,0)
+ZTSK2 I '$D(XQY) K ZTREQ Q  ;Leave task
+"RTN","XQ1",171,0)
+ D UI^XQ12
+"RTN","XQ1",172,0)
+ Q:'$D(^DIC(19,XQY,0))  S XQY0=^(0),XQT=$P(XQY0,U,4) Q:XQT'="A"&(XQT'="P")&(XQT'="R")
+"RTN","XQ1",173,0)
+ ;Kernel no longer supports reseting priority
+"RTN","XQ1",174,0)
+ ;S X=$P(XQY0,U,8) I X>0,X<11 X ^%ZOSF("PRIORITY")
+"RTN","XQ1",175,0)
+ I $P(XQY0,U,3)]""!($D(XQUIT)) S XQT="KILL"
+"RTN","XQ1",176,0)
+ ;
+"RTN","XQ1",177,0)
+ S %=$$S^%ZTLOAD("Run Task")
+"RTN","XQ1",178,0)
+RUN S:XQT="P"&$L(IO) XQIOP=ION_";"_IOST_";"_IOM_";"_IOSL G @XQT
+"RTN","XQ1",179,0)
+ Q
+"RTN","XU8P672")
+0^19^B2195161^n/a
+"RTN","XU8P672",1,0)
+XU8P672 ;SFIRMFO/MAF -POST-install;04/22/2015  14:20
+"RTN","XU8P672",2,0)
+ ;;8.0;KERNEL;**672**;APR 22, 2015;Build 28
+"RTN","XU8P672",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XU8P672",4,0)
+ D BMES^XPDUTL("                    *** Running post-init for patch XU*8.0*672 ***")
+"RTN","XU8P672",5,0)
+ N XUPKGID,XUPKGFL,DA,X,XUFLG
+"RTN","XU8P672",6,0)
+ S XUPKGID=$O(^DIC(9.4,"B","KERNEL",0)) I $D(^DIC(9.4,+XUPKGID,0)) D
+"RTN","XU8P672",7,0)
+ .D BMES^XPDUTL("Checking system for package file entry for KERNEL that is associated")
+"RTN","XU8P672",8,0)
+ .D MES^XPDUTL("with patient merge - delete entry")
+"RTN","XU8P672",9,0)
+ .S X=0,XUFLG=0
+"RTN","XU8P672",10,0)
+ .F X=0:0 S X=$O(^DIC(9.4,XUPKGID,20,X)) Q:X'>0  I $D(^DIC(9.4,XUPKGID,20,X,0)),$P($G(^DIC(9.4,XUPKGID,20,X,0)),"^",1)=2 S XUPKGFL=X D
+"RTN","XU8P672",11,0)
+ . .S DA(1)=XUPKGID,DA=XUPKGFL S DIK="^DIC(9.4,"_DA(1)_",20,"
+"RTN","XU8P672",12,0)
+ . .D ^DIK D BMES^XPDUTL("*** Entry found and deleted!") S XUFLG=1
+"RTN","XU8P672",13,0)
+ . .K DIK,DA
+"RTN","XU8P672",14,0)
+ . . Q
+"RTN","XU8P672",15,0)
+ .Q
+"RTN","XU8P672",16,0)
+ I 'XUFLG D BMES^XPDUTL("*** No entry found!")
+"RTN","XU8P672",17,0)
+ D BMES^XPDUTL(" ")
+"RTN","XU8P672",18,0)
+ Q
+"RTN","XU8P672E")
+0^20^B7918706^n/a
+"RTN","XU8P672E",1,0)
+XU8P672E ;SFISC/RSD - Environment Check ;06/24/2008
+"RTN","XU8P672E",2,0)
+ ;;8.0;KERNEL;**672**;Jul 10, 1995;Build 28
+"RTN","XU8P672E",3,0)
+ ;Per VHA Directive 2004-038, this routine should not be modified.
+"RTN","XU8P672E",4,0)
+ ;during load, XPDENV=0
+"RTN","XU8P672E",5,0)
+ N XFILE
+"RTN","XU8P672E",6,0)
+ S XFILE=$$CHK() Q:'XPDENV
+"RTN","XU8P672E",7,0)
+ ;during install
+"RTN","XU8P672E",8,0)
+ N CNT,DIR,DIU,I,X,XLET,Y
+"RTN","XU8P672E",9,0)
+ I XFILE]"" D
+"RTN","XU8P672E",10,0)
+ . S DIR(0)="Y",DIR("A")="Do you want me to delete the "_XFILE_ " file, #1.5",DIR("B")="NO"
+"RTN","XU8P672E",11,0)
+ . D ^DIR I Y'=1 S XPDQUIT=1 Q  ;don't want to delete, abort install and delete Transport Global
+"RTN","XU8P672E",12,0)
+ . K ^TMP($J) S CNT=0
+"RTN","XU8P672E",13,0)
+ . ;check for LetterMan in ALTERNATE EDITOR file #1.2
+"RTN","XU8P672E",14,0)
+ . D BMES^XPDUTL("Ok, we will delete file 1.5, first need to check if your site is using LetterMan...")
+"RTN","XU8P672E",15,0)
+ . S XLET=0 F  S XLET=$O(^DIST(1.2,XLET)) Q:'XLET  I $G(^(XLET,0))["LETTERMAN" Q
+"RTN","XU8P672E",16,0)
+ . D:XLET
+"RTN","XU8P672E",17,0)
+ .. ;check NEW PERSON file #200, check PREFERRED EDITOR #31.3 for LetterMan
+"RTN","XU8P672E",18,0)
+ .. S I=0 F  S I=$O(^VA(200,I)) Q:'I  S X=$G(^VA(200,I,1)) D:$P(X,U,5)=XLET
+"RTN","XU8P672E",19,0)
+ ... S CNT=CNT+1,^TMP($J,CNT)=I_"^"_$P($G(^VA(200,I,0)),U)
+"RTN","XU8P672E",20,0)
+ ... D REMOV(I,200,31.3) Q
+"RTN","XU8P672E",21,0)
+ .. D REMOV(XLET,1.2,.01) ;remove LetterMan from ALTERNATE EDITOR file.
+"RTN","XU8P672E",22,0)
+ .. Q
+"RTN","XU8P672E",23,0)
+ . S DIU=1.5,DIU(0)="ET" D EN^DIU2,BMES^XPDUTL("File 1.5 deleted")
+"RTN","XU8P672E",24,0)
+ . D MAIL
+"RTN","XU8P672E",25,0)
+ K ^TMP($J)
+"RTN","XU8P672E",26,0)
+ Q
+"RTN","XU8P672E",27,0)
+ ;
+"RTN","XU8P672E",28,0)
+CHK() ;check file 1.5  Returns: file name or null if ENTITY.
+"RTN","XU8P672E",29,0)
+ N X,Y
+"RTN","XU8P672E",30,0)
+ S Y=""
+"RTN","XU8P672E",31,0)
+ I $D(^DIC(1.5,0))#2 S Y=$P(^(0),"^"),Y=$S(Y'="ENTITY":Y,1:"") D:Y]""
+"RTN","XU8P672E",32,0)
+ . S X(1)=" Your site has the CLASS III "_Y_" file, #1.5."
+"RTN","XU8P672E",33,0)
+ . S X(2)="In order to install this patch the file will be deleted during install."
+"RTN","XU8P672E",34,0)
+ . D MES^XPDUTL(.X)
+"RTN","XU8P672E",35,0)
+ Q Y
+"RTN","XU8P672E",36,0)
+ ;
+"RTN","XU8P672E",37,0)
+REMOV(DA,XFIL,XFLD) ;remove value from XFIL(file) and XFLD(field) for record DA
+"RTN","XU8P672E",38,0)
+ N CNT,I,X,XFILE,XLET,XUDATA,Y
+"RTN","XU8P672E",39,0)
+ S XUDATA(XFIL,DA_",",XFLD)="@"
+"RTN","XU8P672E",40,0)
+ D FILE^DIE("","XUDATA")
+"RTN","XU8P672E",41,0)
+ Q
+"RTN","XU8P672E",42,0)
+ ;
+"RTN","XU8P672E",43,0)
+MAIL ;create mail message to send to Forum
+"RTN","XU8P672E",44,0)
+ N I,XMY,XUTEXT,XMTEXT,XMDUZ,XMSUB,XMZ,XMMG
+"RTN","XU8P672E",45,0)
+ S XMY("G.PATCH TRACKING XU_8_672@FORUM.DOMAIN.EXT")=""
+"RTN","XU8P672E",46,0)
+ ;Message for server
+"RTN","XU8P672E",47,0)
+ S XUTEXT(1,0)="XU*8*672"
+"RTN","XU8P672E",48,0)
+ S XUTEXT(2,0)="SITE: "_$G(^XMB("NETNAME"))
+"RTN","XU8P672E",49,0)
+ S XUTEXT(3,0)="DATE: "_$$FMTE^XLFDT(DT)
+"RTN","XU8P672E",50,0)
+ S XUTEXT(4,0)="Installed by: "_$P($G(^VA(200,+$G(DUZ),0)),U)
+"RTN","XU8P672E",51,0)
+ S XUTEXT(5,0)="Install Name: "_$G(XPDNM)
+"RTN","XU8P672E",52,0)
+ S XUTEXT(6,0)=" File "_XFILE_" #1.5 removed"
+"RTN","XU8P672E",53,0)
+ S XUTEXT(7,0)=" The following Users had their PREFERRED EDITOR field #31.3 removed:"
+"RTN","XU8P672E",54,0)
+ F I=1:1 Q:$G(^TMP($J,I))=""  S XUTEXT(I+7,0)=^(I)
+"RTN","XU8P672E",55,0)
+ S XMDUZ=$G(DUZ),XMTEXT="XUTEXT(",XMSUB="Patch XU*8*672 Installation"
+"RTN","XU8P672E",56,0)
+ D ^XMD
+"RTN","XU8P672E",57,0)
+ Q
+"VER")
+8.0^22.2
+"^DD",9.4,9.4,.01,0)
+NAME^RFJ50^^0;1^K:$L(X)>50!($L(X)<4)!'(X'?1P.E) X
+"^DD",9.4,9.4,.01,1,0)
+^.1
+"^DD",9.4,9.4,.01,1,1,0)
+9.4^B
+"^DD",9.4,9.4,.01,1,1,1)
+S ^DIC(9.4,"B",X,DA)=""
+"^DD",9.4,9.4,.01,1,1,2)
+K ^DIC(9.4,"B",X,DA)
+"^DD",9.4,9.4,.01,3)
+Answer must be 4-50 characters in length.
+"^DD",9.4,9.4,.01,21,0)
+^^1^1^2940627^^^^
+"^DD",9.4,9.4,.01,21,1,0)
+The name of this Package.
+"^DD",9.4,9.4,.01,"DT")
+3161219
+"^DD",9.6,9.6,913.1,0)
+DELETE ENV ROUTINE^S^y:Yes;n:No;^INID;1^Q
+"^DD",9.6,9.6,913.1,3)
+Enter 'Yes' if you want the Environment Check Routine deleted at the end of the install.
+"^DD",9.6,9.6,913.1,21,0)
+^.001^3^3^3160307^^^
+"^DD",9.6,9.6,913.1,21,1,0)
+Setting this field to YES will instruct KIDS to delete the Environment
+"^DD",9.6,9.6,913.1,21,2,0)
+Check Routine at the end of the install.
+"^DD",9.6,9.6,913.1,21,3,0)
+
+"^DD",9.6,9.6,913.1,"DT")
+3160307
+"^DD",19,19,82,0)
+DIQ(0)^S^C:Computed Fields;R:Record Number (IEN);B:Both Computed Fields and Record Number (IEN);^82;E1,245^Q
+"^DD",19,19,82,3)
+Select the code to handle displaying Computed Fields and Record Number (IEN).
+"^DD",19,19,82,21,0)
+^^3^3^3180405^
+"^DD",19,19,82,21,1,0)
+This field determines
+"^DD",19,19,82,21,2,0)
+if you want Computed Fields and Record Number (IEN) displayed with each record.
+"^DD",19,19,82,21,3,0)
+Leave this field blank if you don't want Record Number or Computed Fields displayed.
+"^DD",19,19,82,"DT")
+3170727
+"BLD",1583,6)
+^546
+**END**
+**END**
+

--- a/Packages/Kernel/Patches/XU_8.0_672/XU-8_SEQ-546_PAT-672.txt
+++ b/Packages/Kernel/Patches/XU_8.0_672/XU-8_SEQ-546_PAT-672.txt
@@ -1,0 +1,460 @@
+$TXT Created by                    KRN.FO-OAKLAND.DOMAIN.EXT  (KIDS) on Monday, 09/24/18 at 06:09
+=============================================================================
+Run Date: OCT 11, 2018                     Designation: XU*8*672
+Package : XU - KERNEL                         Priority: Mandatory
+Version : 8       SEQ #546                      Status: Released
+                  Compliance Date: NOV 11, 2018
+=============================================================================
+
+Associated patches: (v)XU*8*559    <<= must be installed BEFORE `XU*8*672'
+
+Subject: KIDS fixes
+
+Category: 
+  - Routine
+  - Data Dictionary
+  - Enhancement (Mandatory)
+
+Description:
+============
+
+ Patch XU*8.0*672 contains the following issues for the Kernel Installation
+ and Distribution System (KIDS):
+  
+ 1.  KIDS not removing old parameters when template is changed
+ 2.  Remove AFFECTS RECORD MERGE & PRIMARY HELP FRAME from KIDS 
+ 3.  KIDS doesn't know an Install has been removed
+ 4.  Fix Patch Tracking Message for Global type Builds
+ 5.  PACKAGE file (#9.4) NAME field (#.01) only allows 30 characters
+ 6.  OPTION file (#19), DIQ(0) field (#82), doesn't support parameter 'R'
+     and 'B'
+ 7.  New DIALOG file (#.84) entries have incorrect internal entry number(IEN)
+ 8.  When updating REMOTE PROCEDURE file (#8994) INPUT PARAMETER multiple is
+     not deleted
+ 9.  Modify KIDS to support ENTITY file (#1.5)
+ 10. Modify KIDS to support POLICY file (#1.6), POLICY EVENT file (#1.61),
+     POLICY FUNCTION file (#1.62)
+ 11. Add 2 new KIDS Application Program Interfaces (APIs): LOCK^XPDMENU
+     and RLOCK^XPDMENU
+  
+ Patch Components:
+ -----------------
+ Files & Fields Associated:
+                                                     New/Modified/
+ File Name (#)              Field Name (#)          Deleted
+ -------------              --------------          -------------
+ PACKAGE (9.4)              NAME (.01)              Modified
+ BUILD (9.6)                DELETE ENV
+                             ROUTINE (913.1)        Modified
+ OPTION (19)                DIQ(0) (82)             Modified
+  
+ Forms Associated:
+  
+ Form Name                  File #                  New/Modified/Deleted
+ ---------                  ------                  --------------------
+ XPD EDIT BUILD             9.6                     Modified
+  
+  
+ Mail Groups Associated:
+  
+ Mail Group Name            New/Modified/Deleted
+ ---------------            --------------------
+ N/A                       
+  
+  
+ Options Associated:
+  
+ Option Name                Type                    New/Modified/Deleted
+ -----------                ----                    -------------------- 
+ N/A
+  
+ Protocols Associated:
+  
+ Protocol Name              New/Modified/Deleted
+ -------------              -------------------- 
+ N/A
+  
+  
+ Security Keys Associated:
+  
+ Security Key Name
+ -----------------
+ N/A
+  
+  
+ Templates Associated:
+  
+ Template Name    Type      File Name (Number)      New/Modified/Deleted
+ -------------    ----      ------------------      --------------------
+ N/A
+  
+ Additional Information:
+ -----------------------
+ N/A
+  
+  
+ New Service Requests (NSRs):
+ ----------------------------  
+ N/A
+  
+  
+ Patient Safety Issues (PSIs):
+ -----------------------------
+ N/A
+   
+ Defect Tracking System Ticket(s) & Overview:
+ --------------------------------------------
+  
+ 1. Ticket #708856
+ Problem:
+ --------
+ KIDS doesn't remove old PARAMETERS, field (#10), when installing a
+ PARAMETER TEMPLATE file (#8989.52).
+  
+ Resolution:
+ ----------
+ Modified routine XPDIA3 to delete the PARAMETER multiple before installing
+ the updated template.
+   
+ 2. Ticket #962037
+ Problem:
+ --------
+ Remove outdated links to AFFECTS RECORD MERGE & PRIMARY HELP FRAME
+ in the KIDS edit screens.
+  
+ Resolution:
+ ----------
+ Modified the XPD EDIT BUILD screen 4 to remove the fields and links.
+  
+ 3. Ticket #615220
+ Problem:
+ --------
+ When an Install is delayed for later installation, KIDS allowed the user
+ to delete the Transport Global and then runs the install and no data is
+ installed.
+  
+ Resolution:
+ ----------
+ Modified routine XPDIJ to check if Transport Global still exists before 
+ installing.
+  
+ 4. Ticket #1029686
+ Problem:
+ --------
+ Global type Builds sending incomplete information in Patch Tracking 
+ message.
+  
+ Resolution:
+ ----------
+ Changed routine XPDIGP to add missing information to the Patch Tracking
+ message.
+  
+  
+ 5. Ticket none
+ Problem:
+ --------
+ PACKAGE file (#9.4), only allows names less than 31 characters.
+  
+ Resolution:
+ ----------
+ Modify NAME field (#.01) to allow 50 characters
+  
+  
+ 6. Ticket #I15302677FY17
+  
+ Problem:
+ --------
+ VA FileMan 22.2 Inquire options allows 'R' for Record Number(IEN) and 'B'
+ for Both Computed fields and Record Number.  The OPTION file (#19), DIQ(0)
+ field (#82), only allows 'C' for computed.  This field is used for Options
+ that are Inquires.  It should support the same as FM 22.2
+  
+ Resolution:
+ ----------
+ Modify DIQ(0) field to support 'R','B', and 'C' and modify routine XQ1 to
+ support new parameters.
+  
+  
+ 7. Ticket I15729979FY17
+  
+ Problem:
+ --------
+ When adding a new entry to DIALOG file (#.84), an incorrect IEN is used.
+ The DIALOG NUMBER field (#.01) is DINUMED and KIDS adds wrong number.
+  
+ Resolution:
+ ----------
+ Modify routines XPDIK and XPDE to use the .01 field as the IEN.
+   
+  
+ 8. Ticket I7702063FY16
+  
+ Problem:
+ --------
+ When updating a REMOTE PROCEDURE file, (#8994), entry, the INPUT PARAMETER
+ field, (#2), is merged with existing data.  This doesn't allow the developer
+ to delete an Input Parameter.
+  
+ Resolution:
+ ----------
+ KIDS will now kill the INPUT PARAMETER multiple before updating a Remote
+ Procedure.
+  
+  
+ 9. Ticket none
+  
+ Problem:
+ --------
+ KIDS doesn't support VA FileMan Web Service
+  
+ Resolution:
+ ----------
+ Modify KIDS to transport and install entries in the ENTITY file (#1.5).
+  
+  
+ 10. Ticket none
+  
+ Problem:
+ --------
+ KIDS doesn't support VA FileMan Data Access Control
+  
+ Resolution:
+ ----------
+ Modify KIDS to transport and install entries in the POLICY file (#1.6),
+ APPLICATION ACTION file (#1.61), and POLICY FUNCTION file (#1.62).
+   
+ 11. Ticket none
+  
+ Problem:
+ --------
+ Need API to set LOCK (#3) and REVERSE/NEGATIVE LOCK (#3.01) fields in the
+ OPTION file (#19).
+  
+ Resolution:
+ ----------
+ Added LOCK and RLOCK tags to the XPDMENU routine.
+  
+  
+ Blood Bank Clearance:
+ ---------------------
+ EFFECT ON BLOOD BANK FUNCTIONAL REQUIREMENTS: Patch XU*8.0*672 contains
+ changes to a package referenced in ProPath standard titled: BBM Team
+ Review of VistA Patches. This patch does not alter or modify any VistA
+ Blood Bank software design safeguards or safety critical elements functions.
+  
+ RISK ANALYSIS: Changes made by patch XU*8.0*672 have no effect on Blood 
+ Bank software functionality, therefore RISK is none.
+   
+  
+ Test Sites:
+ -----------
+  West Palm Beach VAMC, FL
+  Charleston VAMC, SC
+  
+ Software and Documentation Retrieval Instructions:
+ -------------------------------------------------- 
+ The software for this patch is being released as a KIDS Build.
+  
+ Documentation describing the new functionality introduced by this patch
+ are available. The preferred method is to retrieve files from
+ download.vista.domain.ext.
+ This transmits the files from the first available server. Sites may also
+ elect to retrieve files directly from a specific server. Sites may
+ retrieve the documentation directly using Secure File Transfer Protocol(SFTP)
+ from the ANONYMOUS.SOFTWARE directory at the following OI Field Offices:
+  
+ Hines:               domain.ext
+ Salt Lake City:      domain.ext 
+  
+ Documentation can also be found on the VA Software Documentation
+ Library at:  http://www4.domain.ext/vdl/
+  
+ Title                                File Name          SFTP Mode
+ -----------------------------------------------------------------
+ Kernel 8.0 Developer's Guide         KRN8_0DG.PDF       Binary
+ Kernel 8.0 Technical Manual          KRN8_0TM.PDF       Binary
+  
+  
+ Patch Installation: 
+   
+ Pre-Installation Instructions:
+ ------------------------------
+ This patch may be installed with users on the system although it is
+ recommended that it be installed during non-peak hours to minimize
+ potential disruption to users.  This patch should take less than 5
+ minutes to install. 
+  
+ This patch contains an Environment Check routine, XU8P672E.  It will
+ check for the existence of WORD LIST file #1.5.  This file was part of
+ the Class III application called LetterMan.  If the file exists, it will
+ be deleted during the Install. It will also remove LetterMan from the
+ ALTERNATE EDITOR file #1.2 and search for any users that have LetterMan
+ set as their PREFERRED EDITOR, field #31.3, in the NEW PERSON file #200.
+ If the file doesn't exists, then the Environment Check routine will
+ continue with the install.  The routine XU8P672 will be removed at the
+ completion of install.
+  
+ Installation Instructions:
+ --------------------------
+ 1. From MAILMAN MENU:
+  
+ 2. Choose the PackMan message containing this patch.
+  
+ 3. Choose the INSTALL/CHECK MESSAGE PackMan option. (see example below  
+    to EXTRACT the KIDS):
+  
+    Go to ACTION and enter X - to extract the KIDS
+    Enter message action (in IN basket): Ignore// Xtract KIDS
+  
+    Select PackMan function: ?
+        Answer with PackMan function NUMBER, or NAME
+      Choose from:
+      1         ROUTINE LOAD
+      2         GLOBAL LOAD
+      3         PACKAGE LOAD
+      4         SUMMARIZE MESSAGE
+      5         PRINT MESSAGE
+      6         INSTALL/CHECK MESSAGE
+      7         INSTALL SELECTED ROUTINE(S)
+      8         TEXT PRINT/DISPLAY
+      9         COMPARE MESSAGE
+   Select PackMan function: INSTALL/CHECK MESSAGE  
+  
+   Message #56647    Unloading KIDS Distribution   XU*8.0*672
+     XU*8.0*672
+  
+   Want to Continue with Load? YES//
+   Loading Distribution...
+  
+     XU*8.0*672
+   Will first run the Environment Check Routine, XU8P672E
+  
+  
+ 4. From the Kernel Installation and Distribution System Menu, select
+    the Installation Menu.  From this menu, you may elect to use the
+    following options. When prompted for the INSTALL NAME enter XU*8.0*672:
+  a. Verify Checksums in Transport Global - This option will allow
+     you to ensure the integrity of the routines that are in the
+     transport global.
+  b. Print Transport Global - This option lets you print the contents
+     of a Transport Global that is currently loaded in the ^XTMP
+     global.
+  c. Compare Transport Global to Current System - This option will
+     allow you to view all changes that will be made when this patch
+     is installed.  It compares all components of this patch
+     (routines, DDs, templates, etc.).
+  d. Backup a Transport Global - This option will create a backup
+     message of any routines exported with this patch. It will not
+     backup any other changes such as Data Dictionaries (DDs) or
+     templates.
+  e. Install Package(s) - This option starts the install process for all
+     Packages in the Transport Global that are part of a distribution.
+  
+ 5. From the Installation Menu, select the Install Package(s) option and
+    When prompted for the INSTALL NAME, enter XU*8.0*672.
+  
+ 6. If prompted 'Want KIDS to Rebuild Menu Trees Upon Completion of
+    Install? NO//' respond NO.
+  
+ 7. When prompted "Want KIDS to INHIBIT LOGONs during the install?
+    NO//" respond NO.
+  
+ 8. If prompted "Want to DISABLE Scheduled Options, Menu Options, 
+    and Protocols? NO//" respond NO. 
+  
+ 9. If prompted "Delay Install (Minutes):  (0 - 60): 0//" respond 0.
+  
+ Post-Installation Instructions:
+ -------------------------------
+ The post install routine XU8P672 will check the PACKAGE file #9.4 for the
+ KERNEL package.  It will then delete any PATIENT MERGE data in the Kernel
+ Package.  This was local data that was accidentally sent out in a previous
+ Kernel patch.  The routine XU8P672 will be removed at the completion of
+ install.
+  
+ Back out and Rollback Procedure:
+ -------------------------------
+ This patch consists of routines, data dictionaries, and a form. During the
+ VistA Installation Procedure of the KIDS build, the installer should
+ back up the modified routines by the use of the 'Backup a Transport
+ Global' action (step 3a in the Installations Instructions below).
+  
+ If rollback/back out is required, the installer can restore the routines
+ using the MailMan message that were saved prior to installing the patch.
+ The changes to the data dictionaries and form are backward compatible.
+
+Routine Information:
+====================
+The second line of each of these routines now looks like:
+ ;;8.0;KERNEL;**[Patch List]**;Jul 10, 1995;Build 28
+
+The checksums below are new checksums, and
+ can be checked with CHECK1^XTSUMBLD.
+
+Routine Name: XPDE
+    Before: B45567472   After: B49613954  **2,15,21,44,51,68,131,182,201,
+                                           229,302,399,507,539,672**
+Routine Name: XPDET
+    Before: B32656156   After: B36528246  **15,39,41,44,51,58,66,137,229,
+                                           393,539,672**
+Routine Name: XPDIA
+    Before: B54051187   After: B57775447  **10,15,21,28,44,58,68,131,145,672**
+Routine Name: XPDIA0
+    Before:  B3762133   After: B34838028  **131,144,672**
+Routine Name: XPDIA1
+    Before: B72722233   After: B73300100  **2,44,51,58,68,85,131,146,182,
+                                           229,302,399,507,539,672**
+Routine Name: XPDIA3
+    Before: B10647739   After: B12998832  **201,302,393,498,672**
+Routine Name: XPDIGP
+    Before: B13701700   After: B15378428  **41,422,672**
+Routine Name: XPDIJ
+    Before: B23600088   After: B25041581  **2,21,28,41,44,68,81,95,108,
+                                           124,229,275,506,672**
+Routine Name: XPDIK
+    Before: B39787924   After: B45151148  **15,58,108,124,146,346,672**
+Routine Name: XPDIL
+    Before: B21320112   After: B21561860  **15,44,58,68,108,422,525,672**
+Routine Name: XPDIP
+    Before: B41486911   After: B36820171  **15,21,28,30,41,44,51,58,83,
+                                           92,100,108,137,229,350,393,517,
+                                           672**
+Routine Name: XPDIST
+    Before: B18641684   After: B18736775  **66,108,185,233,350,393,486,
+                                           539,547,672**
+Routine Name: XPDMENU
+    Before:  B3839322   After:  B5326422  **21,302,672**
+Routine Name: XPDT
+    Before: B82909490   After: B64186009  **2,10,28,41,44,51,58,66,68,
+                                           85,100,108,393,511,539,547,672**
+Routine Name: XPDTA2
+    Before:  B6421820   After: B18380713  **201,498,672**
+Routine Name: XPDTC
+    Before: B47613677   After: B46881298  **10,15,21,39,41,44,58,83,92,
+                                           95,100,108,124,131,463,511,517,
+                                           559,672**
+Routine Name: XPDUTL
+    Before: B24049764   After: B24086795  **21,28,39,81,100,108,137,181,
+                                           275,491,511,559,672**
+Routine Name: XQ1
+    Before: B38155212   After: B38427673  **1,15,59,67,46,151,170,242,446,672**
+Routine Name: XU8P672
+    Before:       n/a   After:  B2195161  **672**
+Routine Name: XU8P672E
+    Before:       n/a   After:  B7918706  **672**
+ 
+Routine list of preceding patches: 144, 145, 346, 446, 498, 506, 525, 547
+                           559
+
+=============================================================================
+User Information:
+Entered By  :                               Date Entered  : SEP 06, 2016
+Completed By:                               Date Completed: OCT 11, 2018
+Released By :                               Date Released : OCT 11, 2018
+=============================================================================
+
+
+Packman Mail Message:
+=====================
+
+$END TXT


### PR DESCRIPTION
Add a patch that was supposed to be installed before the PCE
Standardization patch which was added as a part of the OSEHRA VistA
update.

Change-Id: I44a2484b358a37a03529f5d2e8f1d6750c39738e