### PR TITLE
Add a DUZ argument to autoInstallers

### DIFF
--- a/Scripts/PatchIncrInstallExtractCommit.py
+++ b/Scripts/PatchIncrInstallExtractCommit.py
@@ -55,6 +55,7 @@ class PatchIncrInstallExtractCommit(object):
       testClientConfig = self._config['VistA_Connection']
       self._instance = testClientConfig.get('instance',DEFAULT_INSTANCE)
       self._useSudo = testClientConfig.get('useSudo', False)
+      self._duz = testClientConfig.get('duz', "17")
   def _createTestClient(self):
     testClientConfig = self._config['VistA_Connection']
     system = testClientConfig['system']
@@ -172,6 +173,7 @@ class PatchIncrInstallExtractCommit(object):
       with testClient:
         with testClient2:
           patchApply = PatchSequenceApply(testClient, patchLogDir,testClient2)
+          patchApply._duz= self._duz
           outPatchList = patchApply.generatePatchSequence(inputPatchDir)
           if not outPatchList:
             logger.info("No Patch needs to apply")

--- a/Scripts/PatchIncrInstallExtractCommit.sample.json
+++ b/Scripts/PatchIncrInstallExtractCommit.sample.json
@@ -2,6 +2,7 @@
   "VistA_Connection":
   {
     "system": 1,
+    "duz": "17",
     "instance": "instance name",
     "namespace": "namespace",
     "username": "cacheusername",

--- a/Scripts/PatchSequenceApply.py
+++ b/Scripts/PatchSequenceApply.py
@@ -328,14 +328,16 @@ class PatchSequenceApply(object):
                                       seqNo, logFileName,
                                       multiBuildsList,
                                       files=associateFiles,
-                                      globals=associatedGlobals)
+                                      globals=associatedGlobals,
+                                      duz = self._duz)
 
     else:
       kidsInstaller = KIDSInstallerFactory.createKIDSInstaller(
                             kidsPath, installName, seqNo, logFileName,
                             multiBuildsList,
                             files=associateFiles,
-                            globals=associatedGlobals)
+                            globals=associatedGlobals,
+                            duz = self._duz)
     logger.info("Applying Patch %s" % patchInfo)
     assert kidsInstaller
     return kidsInstaller.runInstallation(self._testClient, self._testClient2)
@@ -406,6 +408,8 @@ def main():
   group.add_argument('-o', '--onlyPatch',
                      help='install specified patch and required patches only'
                           ', this option will ignore the CSV dependencies')
+  parser.add_argument('-d', '--duz', default=17, type=int,
+                help='installer\'s VistA instance\'s DUZ')
 
   result = parser.parse_args();
   print (result)
@@ -420,6 +424,7 @@ def main():
   initConsoleLogging()
   with testClient as vistAClient:
     patchSeqApply = PatchSequenceApply(vistAClient, outputDir)
+    patchSeqApply._duz = result.duz
     assert testClient2
     with testClient2 as vistAClient2:
       patchSeqApply._testClient2 = vistAClient2


### PR DESCRIPTION
Add a DUZ argument which will allow the user to specify the DUZ used
when the command is started.  This is needed for the VeHU instance where
the 17 user does not exist.

Change-Id: Ie3167c69c12672591e9a3e10475c341fbb1bcd80