### PR TITLE
Fix PackageComponents links

### DIFF
--- a/Utilities/Dox/PythonScripts/UtilityFunctions.py
+++ b/Utilities/Dox/PythonScripts/UtilityFunctions.py
@@ -187,7 +187,7 @@ def getRoutineHtmlFileName(routineName, title=""):
 def getRoutineHtmlFileNameUnquoted(routineName, title=""):
     return "Routine_%s.html" % routineName
 
-def getGlobalHtmlFileNameByName(globalName):
+def getGlobalHtmlFileNameByName(globalName, title=""):
     return ("Global_%s.html" %
                         normalizeGlobalName(globalName))
 
@@ -195,7 +195,7 @@ def normalizeGlobalName(globalName):
     import base64
     return base64.urlsafe_b64encode(globalName)
 
-def getPackageHtmlFileName(packageName):
+def getPackageHtmlFileName(packageName, title=""):
     return urllib.quote("Package_%s.html" %
                         normalizePackageName(packageName))
 
@@ -206,7 +206,6 @@ def normalizePackageName(packageName):
     return newName.replace('-', "_").replace('.', '_').replace('/', '_')
 
 def getPackageObjHtmlFileNameUnquoted(optionName, title=""):
-    title = "Routine"
     if "getObjectType" in dir(optionName):
       title = optionName.getObjectType()
     elif "Global" in str(type(optionName)):

--- a/Utilities/Dox/PythonScripts/WebPageGenerator.py
+++ b/Utilities/Dox/PythonScripts/WebPageGenerator.py
@@ -352,10 +352,10 @@ def getGlobalPDFFileNameByName(globalName):
     return ("Global_%s.pdf" %
                         normalizeGlobalName(globalName))
 
-def getICRHtmlFileName(icrEntry):
+def getICRHtmlFileName(icrEntry, title=""):
     return ("%sICR/ICR-%s.html" % (VIVIAN_URL, icrEntry["NUMBER"]))
 
-def getGlobalHtmlFileName(globalVar):
+def getGlobalHtmlFileName(globalVar, title=""):
     if globalVar.isSubFile():
         return getFileManSubFileHtmlFileNameByName(globalVar.getFileNo())
     return getGlobalHtmlFileNameByName(globalVar.getName())
@@ -410,7 +410,7 @@ def getFileManFileHyperLinkWithNameFileNo(GlobalVar):
                                       GlobalVar.getFileNo()))
 
 # sub fileman files related functions
-def getFileManSubFileHtmlFileNameByName(subFileNo):
+def getFileManSubFileHtmlFileNameByName(subFileNo, title=""):
     return urllib.quote("SubFile_%s.html" % subFileNo)
 def getFileManSubFilePDFFileNameByName(subFileNo):
     return urllib.quote("SubFile_%s.pdf" % subFileNo)
@@ -865,13 +865,13 @@ class WebPageGenerator:
                     itemsPerRow.append(sortedItems[i + numPerCol * j])
             self._generateIndexedTableRow(outputFile, itemsPerRow,
                                           httpLinkFunction,
-                                          nameFunc, indexes)
+                                          nameFunc, indexes, title=title)
         outputFile.write("</table>\n</div>\n")
         self.generateNavigationBar(outputFile, indexes, printButton=False,
                                    allButton=False)
 
     def _generateIndexedTableRow(self, outputFile, inputList, httpLinkFunction,
-                                 nameFunc, indexList):
+                                 nameFunc, indexList, title="Routine"):
         outputFile.write("<tr>")
         for item in inputList:
             if item in indexList:
@@ -884,7 +884,7 @@ class WebPageGenerator:
                 if nameFunc:
                     displayName = nameFunc(item)
                 outputFile.write("<td><a class=\"el\" href=\"%s\">%s</a>&nbsp;&nbsp;&nbsp;</td>" %
-                                    (httpLinkFunction(item), displayName))
+                                    (httpLinkFunction(item, title), displayName))
         outputFile.write("</tr>\n")
 
 #===============================================================================
@@ -3741,7 +3741,7 @@ class WebPageGenerator:
         sortedComponents = sorted(sortedComponents, key=lambda s: s.lower())
 
         totalCol = 4
-        self._writeIndex(outputFile, title, totalCol, sortedComponents,
+        self._writeIndex(outputFile, keyVal, totalCol, sortedComponents,
                          getPackageObjHtmlFileName, None, indexList)
         outputFile.write('</div>')
 


### PR DESCRIPTION
Fix the PackageComponent links to take in the keyVal as a title and use it to properly create the links on the index page.

See the most recent OSEHRA VistA DOX update for the broken links. 
https://code.osehra.org/OSEHRA_dox/PackageComponents.html

Fixes #33 