### PR TITLE
Fix color of HL7 Application Parameter

### DIFF
--- a/Utilities/Dox/PythonScripts/UtilityFunctions.py
+++ b/Utilities/Dox/PythonScripts/UtilityFunctions.py
@@ -103,7 +103,7 @@ COLOR_MAP = {
     "Help_Frame":  "moccasin",
     "Form": "cadetblue",
     "Sort_Template": "salmon",
-    "HL7_APPLICATION_PARAMETER": "violetred",
+    "HL7_APPLICATION_PARAMETER": "mediumvioletred",
     "Input_Template": "skyblue",
     "Print_Template": "yellowgreen",
     "Global": "magenta"

--- a/Utilities/Dox/callerGraph_color_legend.dot
+++ b/Utilities/Dox/callerGraph_color_legend.dot
@@ -17,7 +17,7 @@ digraph "caller_colors" {
     "Sort_Template"  [tooltip="Sort_Template" ; penwidth=2; color=salmon];
     "Input_Template"  [tooltip="Input_Template"; penwidth=2; color=skyblue];
     "Print_Template"  [tooltip="Print_Template" ; penwidth=2; color=yellowgreen];
-    "HL7_APPLICATION_PARAMETER" [tooltip="HL7_APPLICATION_PARAMETER"; penwidth=2; color=violetred];
+    "HL7_APPLICATION_PARAMETER" [tooltip="HL7_APPLICATION_PARAMETER"; penwidth=2; color=mediumvioletred];
     label="Legend of Colors"
   }
 }


### PR DESCRIPTION
The 'violetred' color is not visible in the browser window, but 'mediumvioletred' is.  Change the DOT
image and the border color to match.