### PR TITLE
Fix Registration RAS test prompt

### DIFF
--- a/Testing/Functional/RAS/lib/ADTActions.py
+++ b/Testing/Functional/RAS/lib/ADTActions.py
@@ -935,7 +935,10 @@ class ADTActions (Actions):
             self.VistA.write('Summary')
             self.VistA.wait('START DATE:')
             self.VistA.write('t-100')
-            self.VistA.wait('END DATE')
+            index = self.VistA.multiwait(['END DATE','Run statistics'])
+            if index == 1:
+              self.VistA.write('N')
+              self.VistA.wait('END DATE')
             self.VistA.write('t')
             self.VistA.wait('DEVICE')
             self.VistA.write('HOME')


### PR DESCRIPTION
Fix the Registration's RAS test script.  A change is necessary when the
adt_smoke_test call of the "Summary of Dispositions" option asks for a
start date. if the start date falls on the first of the month, there will
be an extra prompt to ask if it wants statistics for the whole month that
the script doesn't account for.

OSEHRA-Id: http://issues.osehra.org/browse/OAT-145
Migrated from OSEHRA Gerrit: Change-Id: I4edbbd35f179c9ee6c69fed3d8d430ebd0b97f6b