### PR TITLE
Fix ICR table for globals

### DIFF
--- a/Utilities/Dox/PythonScripts/WebPageGenerator.py
+++ b/Utilities/Dox/PythonScripts/WebPageGenerator.py
@@ -1678,15 +1678,15 @@ class WebPageGenerator:
                 description += value
         row = [icrLink, subscribingPackage, fieldsReferenced, description]
         icrTable.append(row)
-        self.writeGenericTablizedHtmlData(headerList, icrTable, outfile, "icrVals")
-        if self._generatePDFBundle:
-            pdfRow = [icrLinkPDF, subscribingPackagesPDF,
-                      fieldsReferencedPDF, generateParagraph(description)]
-            icrTablePDF.append(pdfRow)
-            columns = 10
-            columnWidth = self.doc.width/columns
-            colWidths = [columnWidth, columnWidth * 2, columnWidth * 3, columnWidth * 4]
-            self.__writeGenericTablizedPDFData__(headerList, icrTablePDF, pdf,
+      self.writeGenericTablizedHtmlData(headerList, icrTable, outfile, "icrVals")
+      if self._generatePDFBundle:
+          pdfRow = [icrLinkPDF, subscribingPackagesPDF,
+                    fieldsReferencedPDF, generateParagraph(description)]
+          icrTablePDF.append(pdfRow)
+          columns = 10
+          columnWidth = self.doc.width/columns
+          colWidths = [columnWidth, columnWidth * 2, columnWidth * 3, columnWidth * 4]
+          self.__writeGenericTablizedPDFData__(headerList, icrTablePDF, pdf,
                                                   columnWidths=colWidths, isString=False)
 
     def _updatePackageDepDict(self, package, depDict, packDepDict):


### PR DESCRIPTION
The table was being created each time a row was added. Shift the table
creation code out of the loop that generates rows.

Change-Id: I16370dec2c10fa9de90d2151abee4dc92a227642