### PR TITLE
Fix Scheduling RAS test for Jan 2019 Update

### DIFF
--- a/Packages/Scheduling/Testing/RAS/SCMain01_suite.py
+++ b/Packages/Scheduling/Testing/RAS/SCMain01_suite.py
@@ -392,7 +392,7 @@ def sc_test010(test_suite_details):
                                  ['RACE', ''],
                                  ['MARITAL STATUS', 'MARRIED'],
                                  ['RELIGIOUS PREFERENCE', 'CELTICISM'],
-                                 ['TEMPORARY ADDRESS ACTIVE', 'NO'],
+                                 ['ADDRESS ACTIVE', 'NO'],
                                  ['PHONE NUMBER', ''],
                                  ['PAGER NUMBER', '']], emailAddress = 'email@example.org')
         SC.signon()


### PR DESCRIPTION
The prompt for the demographic of "Temporary Address Active" has been
changed to "TEMP MAILING ADDRESS ACTIVE".  Switch the set_demographics command to
only look for the last two words like the get_demographics function does

This prompt change occurs in the January 2019 FOIA release.

Change-Id: I798a35994e8dc031413c10829977646d0fc60be5