### PR TITLE
Fix creation of RPC listener

### DIFF
--- a/Python/vista/OSEHRAHelper.py
+++ b/Python/vista/OSEHRAHelper.py
@@ -107,10 +107,10 @@ class ConnectMUMPS(object):
       VistAboxvol = ''
       for i in range(test[0], test[1]):
         VistAboxvol = VistAboxvol + match[2][i]
-      self.boxvol = VistAboxvol
+      self.boxvol = VistAboxvol.strip()
     else:
       self.wait_re(volume + ':.+\s', None)
-      self.boxvol = self.connection.after
+      self.boxvol = self.connection.after.strip()
 
   def IEN(self, file, objectname):
     self.write('S DUZ=1 D Q^DI')

--- a/Python/vista/OSEHRASetup.py
+++ b/Python/vista/OSEHRASetup.py
@@ -310,8 +310,13 @@ def setupBoxVolPair(VistA,volume_set,site_name,tcp_port):
   VistA.wait("OK")
   VistA.write("Y")
   VistA.wait("BOX-VOLUME PAIR")
-  VistA.write(VistA.boxvol + '\r')
-  VistA.wait("Select PORT")
+  VistA.write(VistA.boxvol)
+  VistA.wait("OK")
+  VistA.write("Y")
+  index = VistA.multiwait(["BOX-VOLUME","Select PORT"])
+  if index == 0:
+    VistA.write("")
+    VistA.wait("Select PORT")
   VistA.write(tcp_port + '\rY')
   if VistA.type=='cache':
     VistA.write('1\r1\r1\r')

--- a/Python/vista/OSEHRASetup.py
+++ b/Python/vista/OSEHRASetup.py
@@ -318,10 +318,7 @@ def setupBoxVolPair(VistA,volume_set,site_name,tcp_port):
     VistA.write("")
     VistA.wait("Select PORT")
   VistA.write(tcp_port + '\rY')
-  if VistA.type=='cache':
-    VistA.write('1\r1\r1\r')
-  else:
-    VistA.write('1\r\r\r')
+  VistA.write('1\r1\r1\r')
   VistA.wait("Select OPTION")
   VistA.write("")
 


### PR DESCRIPTION
The RPC listener setup was working on Cache but not GT.M.  Fix the
box-volume pair to not have any whitespace via a ".strip()" call and
ensure that the Listener setup relies less on multiple "enter" runs.

Change-Id: I901c784111cf84478f018c3330e749ea5c32beec