### PR TITLE
Remove erroneous continue from Source code display

### DIFF
--- a/Utilities/Dox/PythonScripts/WebPageGenerator.py
+++ b/Utilities/Dox/PythonScripts/WebPageGenerator.py
@@ -2144,8 +2144,6 @@ class WebPageGenerator:
                             self.__parseReadCmd__(readCmdMatches, routine, currentEntryPoint+"+"+str(entryOffset))
                         if WRITE_CMD.search(line):
                             self.__parseWriteCmd__(line, routine, currentEntryPoint+"+"+str(entryOffset))
-                        if lineNo > 1:
-                           continue
                         outputFile.write(line)
                         lineNo += 1
                         entryOffset += 1


### PR DESCRIPTION
Remove the two lines that used to check for the "justComment" flag when
writing out the source code pages for routines.  With the flag gone,
only the first two lines will be written.

Change-Id: I497f0e7b7b4cdc606ae2d6d688e76d78d4f56367