### PR TITLE
Use XPAR to set XU522 entry

### DIFF
--- a/Python/vista/OSEHRASetup.py
+++ b/Python/vista/OSEHRASetup.py
@@ -899,6 +899,10 @@ def registerVitalsCPRS(VistA):
   VistA.wait(PROMPT,60)
   VistA.write('D EN^XPAR(\"SYS\",\"GMV GUI VERSION\",GMVGUI,1)')
 
+def removeCAPRILogin(VistA):
+  VistA.wait(PROMPT,60)
+  VistA.write('D EN^XPAR(\"SYS\",\"XU522\",1,\"Y\")')
+
 def addDoctor(VistA,name,init,SSN,sex,AC,VC1):
   # Adds a Doctor user into the system via the User Management Menu as
   # the System Manager.

--- a/Testing/Setup/PostImportSetupScript.py.in
+++ b/Testing/Setup/PostImportSetupScript.py.in
@@ -96,6 +96,9 @@ if VistA.type=='cache':
 # Start TaskMan through the XUP Menu system.
 OSEHRASetup.restartTaskMan(VistA)
 
+# Remove "old-style" logins
+OSEHRASetup.removeCAPRILogin(VistA)
+
 #Create the System Manager
 OSEHRASetup.addSystemManager(VistA)
 


### PR DESCRIPTION
Use the XPAR entry point to set the XU522 parameter to "Y".  This
will disable the CAPRI login.

Change-Id: I8e28cee85e21b1e0a9f52796fc7a57de603bce7b