### PR TITLE
Add '--force-install' to get Azure working again

### DIFF
--- a/Scripts/Install/GTM/install.sh
+++ b/Scripts/Install/GTM/install.sh
@@ -128,9 +128,9 @@ fi
 # --ucaseonly-utils - override default to install only uppercase utilities
 #                     this follows VistA convention of uppercase only routines
 if [ "$installYottaDB" = "true" ] ; then
-    ./ydbinstall --ucaseonly-utils --installdir /opt/yottadb/"$gtm_ver"_"$gtm_arch" $gtm_ver
+    ./ydbinstall --force-install --ucaseonly-utils --installdir /opt/yottadb/"$gtm_ver"_"$gtm_arch" $gtm_ver
 else
-    ./ydbinstall --gtm --ucaseonly-utils --installdir /opt/lsb-gtm/"$gtm_ver"_"$gtm_arch" $gtm_ver
+    ./ydbinstall --force-install --gtm --ucaseonly-utils --installdir /opt/lsb-gtm/"$gtm_ver"_"$gtm_arch" $gtm_ver
 fi
 # Remove ydbinstall script as it is unnecessary
 rm ./ydbinstall


### PR DESCRIPTION
Add the '--force-install' parameter to the install.sh file which is used
to generate the VistA instance in the Azure Continuous Integration.  It
requires the paramter for Ubuntu 16.04 installs which is the OS for our
CI tests.

Change-Id: Ib0028a20359cb78cab665488f2aae2947604856a