### PR TITLE
Add exceptions for OSEHRA VistA update from Feb 2019

### DIFF
--- a/Packages/Imaging/XINDEXException/GTM.MAGDHPS
+++ b/Packages/Imaging/XINDEXException/GTM.MAGDHPS
@@ -1,0 +1,1 @@
+MAGIP183     F - Call to this MISSING LABEL (see INVOKED BY list).

--- a/Packages/Mental Health/XINDEXException/GTM.YTQAPI2C
+++ b/Packages/Mental Health/XINDEXException/GTM.YTQAPI2C
@@ -1,0 +1,1 @@
+SPECIAL+149  F - Reference to routine '^YTQAPI2D'. That isn't in this UCI.

--- a/Packages/Outpatient Pharmacy/XINDEXException/Cache.PSOERXA1
+++ b/Packages/Outpatient Pharmacy/XINDEXException/Cache.PSOERXA1
@@ -1,2 +1,3 @@
 PARSE+11     F - General Syntax Error.
 PARSE+24     F - General Syntax Error.
+PARSE+27     F - General Syntax Error.

--- a/Packages/Outpatient Pharmacy/XINDEXException/GTM.PSOERXA1
+++ b/Packages/Outpatient Pharmacy/XINDEXException/GTM.PSOERXA1
@@ -2,3 +2,4 @@ PARSE+11     F - General Syntax Error.
 PARSE+11     F - General Syntax Error.
 PARSE+24     F - General Syntax Error.
 PARSE+24     F - General Syntax Error.
+PARSE+27     F - General Syntax Error.

--- a/Packages/Toolkit/XINDEXException/Cache.XTHC10
+++ b/Packages/Toolkit/XINDEXException/Cache.XTHC10
@@ -1,2 +1,3 @@
 GETURL+26    W - Invalid local variable name.
 GETURL+26    W - Invalid local variable name.
+$$ERROR      F - Call to this MISSING LABEL (see INVOKED BY list).

--- a/Packages/Toolkit/XINDEXException/GTM.XTHC10
+++ b/Packages/Toolkit/XINDEXException/GTM.XTHC10
@@ -1,2 +1,3 @@
 GETURL+26    W - Invalid local variable name.
 GETURL+26    W - Invalid local variable name.
+$$ERROR      F - Call to this MISSING LABEL (see INVOKED BY list).

--- a/Packages/Web Services Client/XINDEXException/Cache.XOBWD
+++ b/Packages/Web Services Client/XINDEXException/Cache.XOBWD
@@ -1,1 +1,2 @@
 ADDPROXY+8   F - Cache Object doesn't exist.
+ADDPROXY+9   F - Cache Object doesn't exist.

--- a/Packages/Web Services Client/XINDEXException/Cache.XOBWLIB
+++ b/Packages/Web Services Client/XINDEXException/Cache.XOBWLIB
@@ -4,3 +4,9 @@ GETRESTF+3   F - Cache Object doesn't exist.
 GETREST+4    F - Cache Object doesn't exist.
 EOSTAT+3     F - Cache Object doesn't exist.
 EOHTTP+3     F - Cache Object doesn't exist.
+GETFAC+4     F - Cache Object doesn't exist.
+GETPROXY+5   F - Cache Object doesn't exist.
+GETRESTF+4   F - Cache Object doesn't exist.
+GETREST+5    F - Cache Object doesn't exist.
+EOSTAT+4     F - Cache Object doesn't exist.
+EOHTTP+4     F - Cache Object doesn't exist.

--- a/Packages/Web Services Client/XINDEXException/Cache.XOBWSSL
+++ b/Packages/Web Services Client/XINDEXException/Cache.XOBWSSL
@@ -1,1 +1,2 @@
 GETCFG+7     F - Cache Object doesn't exist.
+GETCFG+8     F - Cache Object doesn't exist.

--- a/Packages/Web Services Client/XINDEXException/Cache.XOBWU1
+++ b/Packages/Web Services Client/XINDEXException/Cache.XOBWU1
@@ -1,1 +1,2 @@
 BUILD+3      F - Cache Object doesn't exist.
+BUILD+5      F - Cache Object doesn't exist.


### PR DESCRIPTION
Add the XINDEXExceptions for XINDEX error introduced in the OSEHRA VistA
update for February 2019

Change-Id: I943da971dd6d19ad8d40746d96ffcf197a0fbfd2