### PR TITLE
Add escaping for "$" character in routine names

### DIFF
--- a/Utilities/Dox/PythonScripts/GraphGenerator.py
+++ b/Utilities/Dox/PythonScripts/GraphGenerator.py
@@ -216,6 +216,7 @@ class GraphGenerator:
 
         dirName = os.path.join(self._outDir, packageName)
         normalizedName = normalizeName(routineName)
+        normalizedName = normalizedName.replace("$","\$")
         dotFilename = os.path.join(dirName, "%s%s.dot" % (normalizedName, routineSuffix))
 
         with open(dotFilename, 'wb') as output:


### PR DESCRIPTION
Add an escaping "\" for the "$" character when passing a normalize routine
name to the dox executable. These are valid names and images should be
generated for them

Change-Id: I31f722258f2aaf85cf1ef966aa787d465263ad0d