### PR TITLE
Add exceptions for additional OSEHRA VistA updates

### DIFF
--- a/Packages/MailMan/XINDEXException/GTM.XMLImportErr
+++ b/Packages/MailMan/XINDEXException/GTM.XMLImportErr
@@ -1,0 +1,20 @@
++2           F - UNDEFINED COMMAND (rest of line not checked).
++3           F - UNDEFINED COMMAND (rest of line not checked).
++5           F - UNDEFINED COMMAND (rest of line not checked).
++7           F - UNDEFINED COMMAND (rest of line not checked).
++8           F - UNDEFINED COMMAND (rest of line not checked).
++10          F - UNDEFINED COMMAND (rest of line not checked).
+XMLImportId+2F - UNDEFINED COMMAND (rest of line not checked).
+XMLImportId+4F - UNDEFINED COMMAND (rest of line not checked).
+XMLImportId+8F - UNDEFINED COMMAND (rest of line not checked).
+XMLImportId+9F - UNDEFINED COMMAND (rest of line not checked).
+F - UNDEFINED COMMAND (rest of line not checked).
+F - Call to missing label '$$XMLIMPORTID' in this routine.
++4           F - Call to missing label '$$XMLIMPORTLOCATION' in this routine.
++6           F - Call to missing label '$$XMLIMPORTLOCATION' in this routine.
++9           F - Call to missing label '$$XMLIMPORTLOCATION' in this routine.
+F - Call to missing label '$$XMLIMPORTLOCATION' in this routine.
+XMLImportNS  F - Call to missing label '$$XMLIMPORTLOCATION' in this routine.
+F - Call to missing label 'XMLImportBadTagchild' in this routine
++4           F - Reference to routine '^%apiOBJ'. That isn't in this UCI.
+F - Reference to routine '^%occMessages'. That isn't in this UCI


### PR DESCRIPTION
Add the XINDEXExceptions for the patches that were missed in the
first update to OSEHRA VistA for February 2019

Change-Id: Ide2c9bd9c4a9aa123fbd6a59058d93d49a5b3bbe