### PR TITLE
Add escaping for entry point prompts

### DIFF
--- a/Utilities/Dox/PythonScripts/WebPageGenerator.py
+++ b/Utilities/Dox/PythonScripts/WebPageGenerator.py
@@ -3020,7 +3020,7 @@ class WebPageGenerator:
                  }
       for key in entryDict:
         if key in entry:
-          outstring += "<li>%s %s</li>" % (entryDict[key],entry[key])
+          outstring += "<li>%s %s</li>" % (entryDict[key],entry[key].replace('<','&lt').replace('>','&gt'))
       outstring +=  "</ul>"
       return outstring
 


### PR DESCRIPTION
Add some escaping to allow '<' and '>' to pass to the web page without
trying to create HTML tags with them for the Read and Write commands

Change-Id: I3b95fafdecc5cdd0742718a73ab111538b8605e5