### PR TITLE
Fix vistaRepoDir usage

### DIFF
--- a/Scripts/VistAMComponentExtractor.py
+++ b/Scripts/VistAMComponentExtractor.py
@@ -64,7 +64,7 @@ class VistADataExtractor:
     self._outputResultDir = outputResultDir
     self._packagesDir = os.path.join(self._vistARepoDir, "Packages")
     assert os.path.exists(self._packagesDir)
-    self._packagesCSV = os.path.normpath(os.path.join(_vistARepoDir,
+    self._packagesCSV = os.path.normpath(os.path.join(self._vistARepoDir,
                                                  "Packages.csv"))
     assert os.path.exists(self._packagesCSV)
     self._routineOutputFile = os.path.join(self._outputResultDir, "Routines.ro")


### PR DESCRIPTION
During init, the _vistARepoDir is missing the "self." to make it a
valid usage.

Change-Id: Ia493727fd2f328ea61b0e5bd16d47af875fb6804