### PR TITLE
Clean-up code that generates the list of files to process

### DIFF
--- a/Utilities/Dox/FileManGlobalDataParser.cmake.in
+++ b/Utilities/Dox/FileManGlobalDataParser.cmake.in
@@ -20,28 +20,6 @@ endif()
 
 message(STATUS "Gathering FileMan information...")
 
-# '101'    Protocol
-# '8994'   Remote Procedure
-# '19'     Option
-# '779.2'  HLO Application
-# '9.7'    Install
-# '.5'     Function
-# '409.61' List Template
-# '19.1'   Security Key
-# '9.2'    Help Frame
-# '.403'   Form
-# '.401'   Sort Template
-# '771'    HL7 APPLICATION PARAMETER
-
-
-if(@GENERATE_VIVIAN@)
-  set(GENERATE_ALL "-all")
-  list(APPEND fileNos "101" "8994" "19" "779.2" "9.7"  ".5" "409.61" "19.1" "9.2" ".403" ".401" "771")
-else()
-  set(GENERATE_ALL "")
-  list(APPEND fileNos "101" "8994")
-endif()
-
 # Run FileMan Global Data Parser script
 # Creates 'Routine-Ref.json', which is used by WebPageGenerator
 execute_process(COMMAND
@@ -52,8 +30,7 @@ execute_process(COMMAND
   -o @DOCUMENT_VISTA_OUTPUT_DIR@
   -lf @LOG_OUTPUT_DIR@
   @GENERATE_LOCAL_LINKS@
-  ${GENERATE_ALL}
-  ${fileNos}
+  -all
   ERROR_VARIABLE error RESULT_VARIABLE retValue)
 if(NOT retValue EQUAL 0)
   message(FATAL_ERROR "Error running FileMan Global Data Parser:\n\n${error}")


### PR DESCRIPTION
Remove '-all' and 'fileNos' arguments from FileManGlobalDataParser.cmake.
Always choose '-all'.

A list of file numbers is no longer accepted with '-all'. Use
'-f [fileNos]' to specify a list of filenumbers

https://issues.osehra.org/browse/VIVIAN-453