### PR TITLE
Standarize DOX and ViViaN URL usage of trailing slash

### DIFF
--- a/Utilities/Dox/PythonScripts/FileManDataToHtml.py
+++ b/Utilities/Dox/PythonScripts/FileManDataToHtml.py
@@ -93,7 +93,7 @@ def _getRoutineHRefLink(dataEntry, routineName, **kargs):
   return routineName[:pos] + link + routineName[pos+len(rtnName):]
 
 def getPackageHRefLink(pkgName):
-  value = "<a href=\"%s%s\">%s</a>" % (DOX_URL,
+  value = "<a href=\"%s/%s\">%s</a>" % (DOX_URL,
                                        getPackageHtmlFileName(pkgName),
                                        pkgName)
   return value

--- a/Utilities/Dox/PythonScripts/UtilityFunctions.py
+++ b/Utilities/Dox/PythonScripts/UtilityFunctions.py
@@ -117,15 +117,15 @@ COLOR_MAP = {
 
 def getDOXURL(local):
     if local:
-        return "../dox/"
+        return "../dox"
     else:
-        return "https://code.osehra.org/dox/"
+        return "https://code.osehra.org/dox"
 
 def getViViaNURL(local):
     if local:
         return local
     else:
-        return "https://code.osehra.org/vivian/files/"
+        return "https://code.osehra.org/vivian/files"
 
 ###############################################################################
 
@@ -260,7 +260,7 @@ def getRoutineHRefLink(rtnName, dox_url, **kargs):
     if crossRef:
         routine = crossRef.getRoutineByName(rtnName)
         if routine:
-            return '<a href=\"%s%s\">%s</a>' % (dox_url,
+            return '<a href=\"%s/%s\">%s</a>' % (dox_url,
                                                 getPackageComponentLink(routine),
                                                 rtnName)
     return None


### PR DESCRIPTION
Ensure that none of the hard-coded URLS for ViViaN or DOX have a trailing slash.
Set the generation of the URLs to include the slash at the time of formatting