### PR TITLE
Add exceptions for OSEHRA VistA update for May 2019

### DIFF
--- a/Packages/Dental/XINDEXException/Cache.DENTV071
+++ b/Packages/Dental/XINDEXException/Cache.DENTV071
@@ -1,0 +1,3 @@
+RESTORE+41   F - Reference to routine '^DENTVICD'. That isn't in this UCI.
+QUICK+6      F - Reference to routine '^DSICCPT'. That isn't in this UCI.
+RESTORE+24   F - Reference to routine '^DSICCPT'. That isn't in this UCI.

--- a/Packages/Dental/XINDEXException/GTM.DENTV071
+++ b/Packages/Dental/XINDEXException/GTM.DENTV071
@@ -1,0 +1,3 @@
+RESTORE+41   F - Reference to routine '^DENTVICD'. That isn't in this UCI.
+QUICK+6      F - Reference to routine '^DSICCPT'. That isn't in this UCI.
+RESTORE+24   F - Reference to routine '^DSICCPT'. That isn't in this UCI.

--- a/Packages/Health Summary/XINDEXException/Cache.GMTSSCD
+++ b/Packages/Health Summary/XINDEXException/Cache.GMTSSCD
@@ -1,0 +1,1 @@
+MAIN+4       F - Reference to routine '^SPNHS0'. That isn't in this UCI.

--- a/Packages/Health Summary/XINDEXException/GTM.GMTSSCD
+++ b/Packages/Health Summary/XINDEXException/GTM.GMTSSCD
@@ -1,0 +1,1 @@
+MAIN+4       F - Reference to routine '^SPNHS0'. That isn't in this UCI.

--- a/Packages/Virtual Patient Record/XINDEXException/Cache.VPRHS
+++ b/Packages/Virtual Patient Record/XINDEXException/Cache.VPRHS
@@ -1,0 +1,2 @@
+P1+1         F - Undefined Function.
+NEW+2        F - Undefined Function.

--- a/Packages/Virtual Patient Record/XINDEXException/GTM.VPRHS
+++ b/Packages/Virtual Patient Record/XINDEXException/GTM.VPRHS
@@ -1,0 +1,2 @@
+P1+1         F - Undefined Function.
+NEW+2        F - Undefined Function.


### PR DESCRIPTION
Add the exceptions for the new XINDEX errors added by the patching
done to update OSEHRA VistA through May 2019.

Change-Id: Iceb30bed86a06770789e41a063af6278a1599791