### PR TITLE
Re-enable colors in DOX Graph display

### DIFF
--- a/Utilities/Dox/PythonScripts/GraphGenerator.py
+++ b/Utilities/Dox/PythonScripts/GraphGenerator.py
@@ -32,7 +32,7 @@ from UtilityFunctions import getPackageHtmlFileName, getPackageDependencyHtmlFil
 from UtilityFunctions import getPackageComponentLink, getPackageGraphEdgePropsByMetrics
 from UtilityFunctions import mergeAndSortDependencyListByPackage, normalizePackageName
 from UtilityFunctions import normalizeName, parseICRJson, readIntoDictionary
-from UtilityFunctions import PACKAGE_COMPONENT_MAP, MAX_DEPENDENCY_LIST_SIZE
+from UtilityFunctions import PACKAGE_COMPONENT_MAP, MAX_DEPENDENCY_LIST_SIZE, COLOR_MAP
 
 class GraphGenerator:
     def __init__(self, crossReference, outDir, docRepDir, dot):
@@ -239,8 +239,8 @@ class GraphGenerator:
                 for depRoutine in callDict:
                     escapedDepRoutineName = re.escape(depRoutine.getName())
                     htmlFileName = getPackageComponentLink(depRoutine)
-                    output.write("\t\t\"%s\" [penwidth=2 color=black URL=\"%s\" tooltip=\"%s\"];\n" %
-                                    (escapedDepRoutineName,
+                    output.write("\t\t\"%s\" [penwidth=2 color=\"%s\" URL=\"%s\" tooltip=\"%s\"];\n" %
+                                    (escapedDepRoutineName,COLOR_MAP[depRoutine.getObjectType()],
                                      htmlFileName, htmlFileName))
                     if str(depPackage) == packageName:
                         output.write("\t\t\"%s\" [style=filled fillcolor=orange];\n" % escapedName)

--- a/Utilities/Dox/PythonScripts/UtilityFunctions.py
+++ b/Utilities/Dox/PythonScripts/UtilityFunctions.py
@@ -97,6 +97,7 @@ PACKAGE_COMPONENT_MAP = {
 MAX_DEPENDENCY_LIST_SIZE = 30
 
 COLOR_MAP = {
+    "Routine": "black",
     "Option": "orangered",
     "Function": "royalblue",
     "List_Manager_Templates": "saddlebrown",


### PR DESCRIPTION
Add the imports and updates necessary to use the DOT generation function
to add in the color for each object instead of defaulting to black.