### PR TITLE
Convert Requirements parsing to Python 2/3

### DIFF
--- a/Utilities/Dox/PythonScripts/DataTableHtml.py
+++ b/Utilities/Dox/PythonScripts/DataTableHtml.py
@@ -473,7 +473,8 @@ def writeTableListInfo(output, tName):
 def safeFileName(name):
   """ convert to base64 encoding """
   import base64
-  return base64.urlsafe_b64encode(name)
+  # b64Encode requires a bytes object but would prefer strings
+  return str(base64.urlsafe_b64encode(name.encode('utf-8')))
 
 def safeElementId(name):
   import base64
@@ -481,4 +482,8 @@ def safeElementId(name):
   it turns out that '=' is not a valid html element id
   remove the padding
   """
-  return base64.b64encode(name, "__").replace('=','').replace('.','')
+  # b64Encode requires a bytes object but would prefer strings
+  name = name.encode('utf-8')
+  extraChr = str('__').encode('utf-8')
+  returnStr = str(base64.b64encode(name, extraChr))
+  return returnStr.replace('=','').replace('.','')

--- a/Utilities/Dox/PythonScripts/RequirementsJSONtoHTML.py
+++ b/Utilities/Dox/PythonScripts/RequirementsJSONtoHTML.py
@@ -1,3 +1,5 @@
+from builtins import str
+from builtins import object
 import json
 import argparse
 import os.path
@@ -50,7 +52,7 @@ summary_list_fields = [
     ('dateUpdated', None, None),
     ('recentUpdate', None, None)
 ]
-class RequirementsConverter:
+class RequirementsConverter(object):
     def __init__(self, outDir):
         self._outDir = outDir
 
@@ -211,11 +213,11 @@ class RequirementsConverter:
 
     def _generateRequirementsSummaryPage(self, inputJson):
         nsrSummary = {"NO NSR":[]}
-        for key in inputJson.keys():
+        for key in inputJson:
           self._generateRequirementsSummaryPageImpl(inputJson, 'Requirement List', key, False)
           for bffEntry in inputJson[key]:
             nsrSummary= self.findNSRValues(bffEntry,nsrSummary)
             self._generateIndividualRequirementsPage(bffEntry)
-        for NSRKey in nsrSummary.keys():
+        for NSRKey in nsrSummary:
           self._generateRequirementsSummaryPageImpl(nsrSummary, 'Requirement List', NSRKey, False)
         self._generateRequirementsSummaryPageImpl(allReqs, 'Requirement List', "All", True)

--- a/Utilities/Dox/PythonScripts/RequirementsParser.py
+++ b/Utilities/Dox/PythonScripts/RequirementsParser.py
@@ -15,12 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #---------------------------------------------------------------------------
+from future import standard_library
+standard_library.install_aliases()
 import RequirementsXLStoJSON
 import RequirementsJSONtoHTML
 
 import argparse
 import os
-import urllib
+import urllib.request, urllib.parse, urllib.error
 
 from LogManager import initLogging, logger
 
@@ -32,16 +34,16 @@ def run(args):
       # First, acquire pages from http://code.osehra.org
       xlsfileName="Open Needs_Epics with BFFs (for Open Source)_Feb2018.xlsx"
       logger.info("Downloading %s from http://code.osehra.org" % xlsfileName)
-      quotedURL = urllib.quote("code.osehra.org/files/requirements/"+xlsfileName)
-      urllib.urlretrieve("http://%s" % quotedURL,xlsfileName)
+      quotedURL = urllib.parse.quote("code.osehra.org/files/requirements/"+xlsfileName)
+      urllib.request.urlretrieve("http://%s" % quotedURL,xlsfileName)
     if args.localPast:
       logger.info("Using local pastData file: %s" % args.localPast)
       pastDataFileName = args.localPast
     else:
       pastDataURL= "code.osehra.org/files/requirements/requirements_July_2017/Requirements.json"
       logger.info("Downloading %s" % pastDataURL)
-      quotedURL = urllib.quote(pastDataURL)
-      urllib.urlretrieve("http://%s" % quotedURL,"oldRequirements.json")
+      quotedURL = urllib.parse.quote(pastDataURL)
+      urllib.request.urlretrieve("http://%s" % quotedURL,"oldRequirements.json")
       pastDataFileName = "oldRequirements.json"
 
     args.ReqJsonFile = os.path.join(args.outDir, "requirements.json")

--- a/Utilities/Dox/PythonScripts/RequirementsXLStoJSON.py
+++ b/Utilities/Dox/PythonScripts/RequirementsXLStoJSON.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from builtins import map
+from builtins import range
 import xlrd
 from xlrd import open_workbook,cellname,xldate_as_tuple
 from datetime import datetime, date, time
@@ -120,13 +122,13 @@ def checkReqForUpdate(curNode,pastJSONObj,curDate):
       diffFlag=False;
       noHistory=False;
       if BFFEntry in pastJSONObj:
-        ret = filter(lambda x: x['name'] == curNode['name'] , pastJSONObj[BFFEntry])
+        ret = [x for x in pastJSONObj[BFFEntry] if x['name'] == curNode['name']]
         if ret:
           for entry in ret:
             diffFlag=False
             if "dateUpdated" in entry:
               foundDate=entry["dateUpdated"]
-            for val in curNode.keys():
+            for val in curNode:
               if val in ["recentUpdate","dateUpdated"]:
                 continue
               oldVal = entry[val] if (val in entry) else None
@@ -163,18 +165,23 @@ def convertExcelToJson(input, output,pastData,curDate):
   fields = None
   all_nodes = dict(); # all the nodes
   fields = sheet.row_values(row_index)
-  fields = map(RequirementsFieldsConvertFunc, fields)
+  fields = list(map(RequirementsFieldsConvertFunc, fields))
   # Read rest of the BFF data from data_row
-  for row_index in xrange(data_row, sheet.nrows):
+  for row_index in range(data_row, sheet.nrows):
     curNode = dict()
     curNode['isRequirement'] = True
     curNode['isRequirement'] = True
-    for col_index in xrange(sheet.ncols):
+    for col_index in range(sheet.ncols):
       cell = sheet.cell(row_index, col_index)
       cType = cell.ctype
       convFunc = typeDictConvert.get(cell.ctype)
       cValue = cell.value
-      if type(cValue) == unicode:
+      replaceFlag = False
+      try:
+          replaceFlag = isinstance(cValue, basestring)
+      except NameError:
+          replaceFlag = isinstance(cValue, str)
+      if replaceFlag:
         cValue = re.sub(r'[^\x00-\x7F]+','', cValue) #cValue.decode('unicode_escape').encode('ascii','ignore')
       if convFunc:
         cValue = convFunc(cValue,col_index)


### PR DESCRIPTION
Convert the Requirements parsing scripts to be able to run in both
Python 2 and Python 3.

* Run futurize steps
* Change type checking for string objects to replace UTF-8 characters
* Ensure that byte objects are sent to name generator in DataTableHTML

Change-Id: Ib1570af27ece72f9f71ffc02a07cf77d584c2aa9