### PR TITLE
Fix exception handling in WebPageGenerator

### DIFF
--- a/Utilities/Dox/PythonScripts/WebPageGenerator.py
+++ b/Utilities/Dox/PythonScripts/WebPageGenerator.py
@@ -2333,7 +2333,7 @@ class WebPageGenerator:
                     # append the content of map outputFile
                     for line in cmapFile:
                         outputFile.write(line)
-            except:
+            except Exception as e:
                 logger.error(e)
 
         total = "%s, Total: %d " % (sectionListHeader, totalPackages)


### PR DESCRIPTION
If an exception were to occur in the Graph Dependency generation
the WebPageGenerator, the 'e' variable that that would be logged doesn't
exist as part of the exception signature. Add it using the Python 3
style exception using "as"

Change-Id: I3ba4b7a5798c045db4b2b4d67c506db6cc1cc37a