### PR TITLE
Add clickable links to Entry Point section

### DIFF
--- a/Utilities/Dox/PythonScripts/WebPageGenerator.py
+++ b/Utilities/Dox/PythonScripts/WebPageGenerator.py
@@ -3083,7 +3083,8 @@ class WebPageGenerator:
                 pdfRow = []
             comments = entryPoints[entry]["comments"] if entryPoints[entry]["comments"] else ""
             # Build table row
-            row.append(entry)
+            sourceLink = "<a href='%s/Routine_%s_source.html#%s'>%s</a>" % (DOX_URL, routine.getName(),entry.split('(')[0],entry)
+            row.append(sourceLink)
             if self._generatePDFBundle:
                 pdfRow.append(generateParagraph(entry))
             val = ""


### PR DESCRIPTION
Now that we have anchors for the entry points in the source code, change
the name of the entry point found in the "Entry Point" subheader to be a
link to the entry point in the terse version of the source code.

Change-Id: I47bd405f8423d5f07443cf02c5ec025a5027e7e7