### PR TITLE
Add automatic attempt to install PExpect via pip

### DIFF
--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -24,6 +24,19 @@ endif()
 option(TEST_VISTA_XINDEX_WARNINGS_AS_FAILURES "Use warnings as a failure condition for XINDEX tests?" OFF)
 option(TEST_VISTA_FRESH "Overwrite the database file during build phase of testing? To remove this option, delete the CMake Cache" OFF)
 
+#Execute the python script which checks for PExpect
+execute_process(COMMAND "${PYTHON_EXECUTABLE}"  "${CMAKE_CURRENT_SOURCE_DIR}/pexpectTest.py" RESULT_VARIABLE return OUTPUT_VARIABLE ERROR)
+if ("${ERROR}" MATCHES "No Pexpect")
+  set(reqFile "requirements.txt")
+  if(WIN32)
+    set(reqFile "requirements-windows.txt")
+  endif()
+  execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-m" "pip" "install" "-r" "${VISTA_SOURCE_DIR}/${reqFile}" "--user" RESULT_VARIABLE return OUTPUT_VARIABLE ERROR)
+  if(NOT return EQUAL 0)
+    message(FATAL_ERROR "PExpect not found or pip is not installed to attempt PExpect installation. Error: ${ERROR}")
+  endif()
+endif()
+
 #-----------------------------------------------------------------------------
 #------ SET UP UNIT TEST ENV -----#
 #-----------------------------------------------------------------------------

--- a/Testing/pexpectTest.py
+++ b/Testing/pexpectTest.py
@@ -1,0 +1,20 @@
+#---------------------------------------------------------------------------
+# Copyright 2019 The Open Source Electronic Health Record Alliance
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#---------------------------------------------------------------------------
+from __future__ import print_function
+try:
+    import pexpect
+except:
+    print("No Pexpect")


### PR DESCRIPTION
Add a small file which looks to import PExpect.  If it cannot be found,
attempt to run pip and use the requirements.txt file to install the
correct set of Python libraries.