### PR TITLE
Convert custom installers to Python 3

### DIFF
--- a/Packages/Automated Lab Instruments/Patches/LA_5.2_88/LA_5.2_88.py
+++ b/Packages/Automated Lab Instruments/Patches/LA_5.2_88/LA_5.2_88.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 The Open Source Electronic Health Record Agent
+# Copyright 2016-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #---------------------------------------------------------------------------
-
+from __future__ import division
+from __future__ import print_function
+from past.utils import old_div
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 from VistAMenuUtil import VistAMenuUtil
 import re
@@ -35,7 +37,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "LA*5.2*88"
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,
@@ -59,7 +61,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
       logger.info("Import global file %s" % (glbFile))
       fileSize = os.path.getsize(glbFile)
       importTimeout = DEFAULT_GLOBAL_IMPORT_TIMEOUT
-      importTimeout += int(fileSize/GLOBAL_IMPORT_BYTE_PER_SEC)
+      importTimeout += int(old_div(fileSize,GLOBAL_IMPORT_BYTE_PER_SEC))
       globalImport.importGlobal(vistATestClient, glbFile, timeout=importTimeout)
 
     """ Requires the installer account to have the ZTMQ security key"""

--- a/Packages/Clinical Case Registries/Patches/ROR_1.5_28/ROR_1.5_28.py
+++ b/Packages/Clinical Case Registries/Patches/ROR_1.5_28/ROR_1.5_28.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 The Open Source Electronic Health Record Agent
+# Copyright 2016-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #---------------------------------------------------------------------------
-
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 
 """ This is an example of custom installer to handle post install questions
@@ -31,7 +31,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "ROR*1.5*28" and int(seqNo) == 28
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Clinical Case Registries/Patches/ROR_1.5_30/ROR_1.5_30.py
+++ b/Packages/Clinical Case Registries/Patches/ROR_1.5_30/ROR_1.5_30.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2018 The Open Source Electronic Health Record Agent
+# Copyright 2018-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 from VistAMenuUtil import VistAMenuUtil
 import re
@@ -36,7 +37,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "ROR*1.5*30"
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Clinical Case Registries/Patches/ROR_1.5_31/ROR_1.5_31.py
+++ b/Packages/Clinical Case Registries/Patches/ROR_1.5_31/ROR_1.5_31.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2018 The Open Source Electronic Health Record Agent
+# Copyright 2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 from VistAMenuUtil import VistAMenuUtil
 import re
@@ -36,7 +37,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "ROR*1.5*31"
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Clinical Case Registries/Patches/ROR_1.5_32/ROR_1.5_32.py
+++ b/Packages/Clinical Case Registries/Patches/ROR_1.5_32/ROR_1.5_32.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2018 The Open Source Electronic Health Record Agent
+# Copyright 2018-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 from VistAMenuUtil import VistAMenuUtil
 import re
@@ -36,7 +37,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "ROR*1.5*32"
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Clinical Case Registries/Patches/ROR_1.5_33/ROR_1.5_33.py
+++ b/Packages/Clinical Case Registries/Patches/ROR_1.5_33/ROR_1.5_33.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2018 The Open Source Electronic Health Record Agent
+# Copyright 2018-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 
 """ This is an example of custom installer to handle post install questions
@@ -31,7 +32,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "ROR*1.5*33"
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Clinical Case Registries/Patches/ROR_1.5_34/ROR_1.5_34.py
+++ b/Packages/Clinical Case Registries/Patches/ROR_1.5_34/ROR_1.5_34.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2019 The Open Source Electronic Health Record Agent
+# Copyright 2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 
 """ This is an example of custom installer to handle post install questions
@@ -31,7 +32,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "ROR*1.5*34" and int(seqNo) == 34
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Clinical Reminders/Patches/PXRM_2.0_27/PXRM_2.0_27.py
+++ b/Packages/Clinical Reminders/Patches/PXRM_2.0_27/PXRM_2.0_27.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2012 The Open Source Electronic Health Record Agent
+# Copyright 2012-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 
 """ This is an example of custom installer to handle post install questions
@@ -31,7 +32,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "PXRM*2.0*27" and int(seqNo) == 20
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Clinical Reminders/Patches/PXRM_2.0_28/PXRM_2.0_28.py
+++ b/Packages/Clinical Reminders/Patches/PXRM_2.0_28/PXRM_2.0_28.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2013 The Open Source Electronic Health Record Agent
+# Copyright 2013-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,13 +14,14 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 
 class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "PXRM*2.0*28" and int(seqNo) == 22
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Clinical Reminders/Patches/PXRM_2.0_63/PXRM_2.0_63.py
+++ b/Packages/Clinical Reminders/Patches/PXRM_2.0_63/PXRM_2.0_63.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 The Open Source Electronic Health Record Agent
+# Copyright 2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 from VistAMenuUtil import VistAMenuUtil
 import re
@@ -35,7 +36,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "PXRM*2.0*63"
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Consult Request Tracking/Patches/GMRC_3.0_99/GMRC_3.0_99.py
+++ b/Packages/Consult Request Tracking/Patches/GMRC_3.0_99/GMRC_3.0_99.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2019 The Open Source Electronic Health Record Agent
+# Copyright 2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 
 """ This is an example of custom installer to handle post install questions
@@ -31,7 +32,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "GMRC*3.0*99" and int(seqNo) == 90
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Generic Code Sheet/Patches/GEC_2.0_40/GEC_2.0_40.py
+++ b/Packages/Generic Code Sheet/Patches/GEC_2.0_40/GEC_2.0_40.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2019 The Open Source Electronic Health Record Agent
+# Copyright 2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 from VistATaskmanUtil import  VistATaskmanUtil
 """ This is an example of custom installer to handle post install questions
@@ -32,7 +33,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "GEC*2.0*40"
     self.kbInstaller = DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Imaging/Patches/MAG_3.0_202/MAG_3.0_202.py
+++ b/Packages/Imaging/Patches/MAG_3.0_202/MAG_3.0_202.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 The Open Source Electronic Health Record Agent
+# Copyright 2016-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 from VistAMenuUtil import VistAMenuUtil
 import re
@@ -35,7 +36,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "MAG*3.0*202"
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Kernel/Patches/XU_8.0_10002/XU_8.0_10002.py
+++ b/Packages/Kernel/Patches/XU_8.0_10002/XU_8.0_10002.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 The Open Source Electronic Health Record Agent
+# Copyright 2016-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 from VistATaskmanUtil import  VistATaskmanUtil
 """ This is an example of custom installer to handle post install questions
@@ -32,7 +33,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "XU*8.0*10002"
     self.kbInstaller = DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Kernel/Patches/XU_8.0_599/XU_8.0_599.py
+++ b/Packages/Kernel/Patches/XU_8.0_599/XU_8.0_599.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2012 The Open Source Electronic Health Record Agent
+# Copyright 2012-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 
 """ This is an example of custom installer to handle post install questions
@@ -31,7 +32,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "XU*8.0*599" and int(seqNo) == 481
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Kernel/Patches/XU_8.0_670/XU_8.0_670.py
+++ b/Packages/Kernel/Patches/XU_8.0_670/XU_8.0_670.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2018 The Open Source Electronic Health Record Agent
+# Copyright 2018-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 from VistAMenuUtil import VistAMenuUtil
 from VistATaskmanUtil import VistATaskmanUtil
@@ -37,7 +38,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "XU*8.0*670"
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Lab Service/Patches/LR_5.2_469/LR_5.2_469.py
+++ b/Packages/Lab Service/Patches/LR_5.2_469/LR_5.2_469.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 The Open Source Electronic Health Record Agent
+# Copyright 2016-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
+from builtins import str
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 from VistAMenuUtil import VistAMenuUtil
 import re
@@ -38,7 +40,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "LR*5.2*469"
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Master Patient Index VistA/Patches/MPIF_1.0_63/MPIF_1.0_63.py
+++ b/Packages/Master Patient Index VistA/Patches/MPIF_1.0_63/MPIF_1.0_63.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 The Open Source Electronic Health Record Agent
+# Copyright 2016-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 from VistATaskmanUtil import  VistATaskmanUtil
 """ This is an example of custom installer to handle post install questions
@@ -32,7 +33,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "MPIF*1.0*63"
     self.kbInstaller = DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Mental Health/Patches/YS_5.01_148/YS_5.01_148.py
+++ b/Packages/Mental Health/Patches/YS_5.01_148/YS_5.01_148.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2019 The Open Source Electronic Health Record Agent
+# Copyright 2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #---------------------------------------------------------------------------
-
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 
 """ This is an example of custom installer to handle post install questions
@@ -31,7 +31,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "YS*5.01*148" and int(seqNo) == 108
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Methicillin Resistant Staph Aurerus Initiative Reports/Patches/MMRS_1.0_4/MMRS_1.0_4.py
+++ b/Packages/Methicillin Resistant Staph Aurerus Initiative Reports/Patches/MMRS_1.0_4/MMRS_1.0_4.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2017 The Open Source Electronic Health Record Agent
+# Copyright 2017-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #---------------------------------------------------------------------------
-
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 
 """ This is an example of custom installer to handle post install questions
@@ -31,7 +31,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "MMRS*1.0*4"
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/National Drug File/Patches/PSN_4.0_533/PSN_4.0_533.py
+++ b/Packages/National Drug File/Patches/PSN_4.0_533/PSN_4.0_533.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 The Open Source Electronic Health Record Agent
+# Copyright 2016-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 from VistAMenuUtil import VistAMenuUtil
 import re
@@ -36,7 +37,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "PSN*4.0*533"
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Order Entry Results Reporting/Patches/OR_3.0_350/OR_3.0_350.py
+++ b/Packages/Order Entry Results Reporting/Patches/OR_3.0_350/OR_3.0_350.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 The Open Source Electronic Health Record Agent
+# Copyright 2016-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 
 """ This is an example of custom installer to handle post install questions
@@ -31,7 +32,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "OR*3.0*350" and int(seqNo) == 362
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Order Entry Results Reporting/Patches/OR_3.0_423/OR_3.0_423.py
+++ b/Packages/Order Entry Results Reporting/Patches/OR_3.0_423/OR_3.0_423.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 The Open Source Electronic Health Record Agent
+# Copyright 2016-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #---------------------------------------------------------------------------
-
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 
 """ This is an example of custom installer to handle post install questions
@@ -31,7 +31,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "OR*3.0*423" and int(seqNo) == 369
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Registration/Patches/DG_5.3_951/DG_5.3_951.py
+++ b/Packages/Registration/Patches/DG_5.3_951/DG_5.3_951.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2019 The Open Source Electronic Health Record Agent
+# Copyright 2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #---------------------------------------------------------------------------
-
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 
 """ This is an example of custom installer to handle post install questions
@@ -31,7 +31,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "DG*5.3*951" and int(seqNo) == 854
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Scheduling/Patches/SD_5.3_627/SD_5.3_627.py
+++ b/Packages/Scheduling/Patches/SD_5.3_627/SD_5.3_627.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 The Open Source Electronic Health Record Agent
+# Copyright 2016-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 
 """ This is an example of custom installer to handle post install questions
@@ -31,7 +32,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "SD*5.3*627"
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/Scheduling/Patches/SD_5.3_658/SD_5.3_658.py
+++ b/Packages/Scheduling/Patches/SD_5.3_658/SD_5.3_658.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2017 The Open Source Electronic Health Record Agent
+# Copyright 2017-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #---------------------------------------------------------------------------
-
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 
 """ This is an example of custom installer to handle post install questions
@@ -31,7 +31,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "SD*5.3*658"
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/VA FileMan/Patches/DI 22.2/VA FILEMAN 22.2.py
+++ b/Packages/VA FileMan/Patches/DI 22.2/VA FILEMAN 22.2.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 The Open Source Electronic Health Record Agent
+# Copyright 2016-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 from VistAMenuUtil import VistAMenuUtil
 import re
@@ -36,7 +37,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "VA FILEMAN 22.2"
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,

--- a/Packages/VBECS/Patches/VBEC_2.0_1/VBEC_2.0_1.py
+++ b/Packages/VBECS/Patches/VBEC_2.0_1/VBEC_2.0_1.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2016 The Open Source Electronic Health Record Agent
+# Copyright 2016-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 from VistAMenuUtil import VistAMenuUtil
 import re
@@ -35,7 +36,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName, seqNo
+    print(kidsInstallName, seqNo)
     assert kidsInstallName == "VBEC*2.0*1"
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,


### PR DESCRIPTION
Simple replacements to bring the custom installers to be ready
for Python 3.

Change-Id: I7f0d9072b95c6dbe6cdb80275bdfb9b18ab0c06b