### PR TITLE
Fix exception throwing for Non-mupmps prints

### DIFF
--- a/Python/vista/OSEHRAHelper.py
+++ b/Python/vista/OSEHRAHelper.py
@@ -37,6 +37,7 @@ import telnetlib
 import TestHelper
 import time
 import re
+import pexpect
 import logging
 import csv
 import socket
@@ -672,9 +673,9 @@ def ConnectToMUMPS(logfile, instance='CACHE', namespace='VISTA',
         try:
           return ConnectLinuxGTM(logfile, instance, namespace, location)
         except:
-          raise "Cannot find a MUMPS instance"
+          raise BaseException("Cannot find a MUMPS instance")
       else:
         try:
           return ConnectLinuxCache(logfile, instance, namespace, location)
         except:
-          raise "Cannot find a MUMPS instance"
+          raise BaseException("Cannot find a MUMPS instance")


### PR DESCRIPTION
Fix the execptions thrown when a problem is found in connecting to a MUMPS
instance to properly throw a BaseExpection class.

Re-import PExpect at the top of the file to stop the GT.M connections from
crashing.

Change-Id: I50ee7744ff50ab051fcc7e550937cb596ec3d2af