### PR TITLE
Add OSEHRAHelper dir to path before running

### DIFF
--- a/Scripts/VistATestClient.py
+++ b/Scripts/VistATestClient.py
@@ -39,6 +39,8 @@ else:
   from pexpect import TIMEOUT
   from winpexpect import winspawn
 
+OSEHRA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),"..", "Python", "vista")
+sys.path.append(OSEHRA_DIR)
 from OSEHRAHelper import ConnectWinCache, ConnectLinuxCache, ConnectLinuxGTM
 
 DEFAULT_TIME_OUT_VALUE = 30


### PR DESCRIPTION
Ensure that the Python/vista directory is in the system path before
the running of the VistAMComponentExtractor.

Change-Id: Ifb53fe6e1f28567542840be11ff69f5b4d9b8c38