### PR TITLE
Fix UTZTMGRSET test for OSEHRAHelper transition

### DIFF
--- a/Packages/Kernel/Testing/RAS/UTZTMGRSET.py
+++ b/Packages/Kernel/Testing/RAS/UTZTMGRSET.py
@@ -47,7 +47,7 @@ class TestZTMGRSET(unittest.TestCase):
             testClient.waitForPrompt()
             connection.send("D PATCH^ZTMGRSET(" + patchNumber + ")\r")
             testClient.waitForPrompt()
-            result = self.lineParser(connection.before, "^ALL DONE")
+            result = self.lineParser(connection.lastconnection, "^ALL DONE")
             if expectedResult:
                 self.assertEqual(result, "ALL DONE", msg="ZTMGRSET Failed")
             else:
@@ -82,7 +82,7 @@ class TestZTMGRSET(unittest.TestCase):
             connection.expect("load:")
             connection.send(patchNumber + "\r")
             testClient.waitForPrompt()
-            result = self.lineParser(connection.before, "^ALL DONE")
+            result = self.lineParser(connection.lastconnection, "^ALL DONE")
             if expectedResult:
                 self.assertEqual(result, "ALL DONE", msg="ZTMGRSET Failed")
             else:


### PR DESCRIPTION
Ensure that the connection values for the UTZTMGRSET test are properly
updated to account for the Connect**** classes that the TestClient now uses.

Change-Id: I0d0f33f3d8404eaf3d29db81beb8c2165aa4f953