### PR TITLE
Remove a leftover encode in LinuxCache

### DIFF
--- a/Python/vista/OSEHRAHelper.py
+++ b/Python/vista/OSEHRAHelper.py
@@ -310,7 +310,7 @@ class ConnectLinuxCache(ConnectMUMPS):
     logging.debug('connection.expect: ' + str(command))
     if command is PROMPT:
       command = self.namespace + '>'
-    rbuf = self.connection.expect_exact(encode(command), tout)
+    rbuf = self.connection.expect_exact(command, tout)
     if rbuf == -1:
         logging.debug('ERROR: expected: ' + command)
         raise TestHelper.TestError('ERROR: expected: ' + command)


### PR DESCRIPTION
The LinuxCache doesn't seem to need additional encoding.  Remove the
encode call.

Change-Id: Ia6167d87fb5fa74cb5e37a0b287d7e63ea556f44