### PR TITLE
Expand encoding usage.

### DIFF
--- a/Python/vista/OSEHRAHelper.py
+++ b/Python/vista/OSEHRAHelper.py
@@ -32,6 +32,7 @@ from builtins import range
 from builtins import object
 import sys
 import codecs
+import chardet
 import os, errno
 import telnetlib
 import TestHelper
@@ -52,10 +53,15 @@ try:
 except ImportError as no_paramiko:
   pass
 
+def determineEncoding(encString):
+  encoding = chardet.detect(encode(encString))['encoding']
+  if not encoding:
+    encoding = "ISO-8859-1"
+  return encoding
+
 def encode(command):
   if sys.version_info[0] == 3:
-    if isinstance(command, str):
-      return codecs.encode(command, 'utf-8','ignore')
+      return codecs.encode(command, 'ISO-8859-1','ignore')
   elif not sys.platform == 'win32':
       return unicode(command)
   else:
@@ -65,7 +71,7 @@ def decode(command):
   if isinstance(command, str):
       return command
   else:
-      return codecs.decode(command, 'utf-8', 'ignore')
+      return codecs.decode(command, determineEncoding(command), 'ignore')
 
 #---------------------------------------------------------------------------
 # Initial Global Variables to use over the course of connecting
@@ -285,7 +291,7 @@ class ConnectWinCache(ConnectMUMPS):
 class ConnectLinuxCache(ConnectMUMPS):
   def __init__(self, logfile, instance, namespace, location='127.0.0.1'):
     super(ConnectMUMPS, self).__init__()
-    self.connection = pexpect.spawn('ccontrol session ' + instance + ' -U ' + namespace, timeout=None, encoding='utf-8')
+    self.connection = pexpect.spawn('ccontrol session ' + instance + ' -U ' + namespace, timeout=None, encoding='utf-8', codec_errors='ignore')
     if len(namespace) == 0:
       namespace = 'VISTA'
     self.namespace = namespace
@@ -387,7 +393,7 @@ class ConnectLinuxGTM(ConnectMUMPS):
   def __init__(self, logfile, instance, namespace, location='127.0.0.1'):
     super(ConnectMUMPS, self).__init__()
     gtm_command = os.getenv('gtm_dist')+'/mumps -dir'
-    self.connection = pexpect.spawn(gtm_command, timeout=None, encoding='utf-8')
+    self.connection = pexpect.spawn(gtm_command, timeout=None, encoding='utf-8', codec_errors='ignore')
     if len(namespace) == 0:
         self.prompt = os.getenv("gtm_prompt")
         if self.prompt == None:

--- a/Scripts/SplitZWR.py
+++ b/Scripts/SplitZWR.py
@@ -24,6 +24,7 @@
 #---------------------------------------------------------------------------
 from builtins import object
 import argparse
+import codecs
 import os
 import sys
 
@@ -37,7 +38,7 @@ class SplitZWR(object):
         else:
            self.num=0
            self.name=nameSplit[0]
-        self.input = open(filepath, 'r')
+        self.input = codecs.open(filepath, 'r', encoding='ISO-8859-1', errors='ignore')
         self.headers = []
         while len(self.headers) < 2:
             self.headers.append(self.input.readline())

--- a/Scripts/VistAMComponentExtractor.py
+++ b/Scripts/VistAMComponentExtractor.py
@@ -18,6 +18,7 @@
 from __future__ import print_function
 from __future__ import with_statement
 from builtins import object
+import codecs
 import sys
 import os
 import subprocess
@@ -164,7 +165,7 @@ class VistADataExtractor(object):
     logfile = os.path.join(self._outputLogDir, "unpackro.log")
     logger.info("Unpack routines from %s to %s" %
                 (routinesOutputFile, outputDir))
-    with open(routinesOutputFile, 'r') as routineFile: # open as txt
+    with codecs.open(routinesOutputFile, 'r', encoding='ISO-8859-1', errors='ignore') as routineFile: # open as txt
       with open(logfile, 'w') as logFile:
         unpack(routineFile, out=logFile, odir=outputDir)
 

--- a/Utilities/Dox/PythonScripts/DataDictionaryParser.py
+++ b/Utilities/Dox/PythonScripts/DataDictionaryParser.py
@@ -29,6 +29,7 @@ import sys
 import subprocess
 import re
 import csv
+import codecs
 import argparse
 
 from datetime import datetime, date, time
@@ -574,7 +575,7 @@ class DataDictionaryListFileLogParser(IDataDictionaryListFileLogParser):
         if not os.path.exists(logFileName):
             logger.error("File: %s does not exist" % logFileName)
             return
-        logFileHandle = open(logFileName, 'r')
+        logFileHandle = codecs.open(logFileName, 'r', encoding='ISO-8859-1', errors='ignore')
         baseName = os.path.basename(logFileName)
         fileNo = baseName[:-len(".schema")]
         self._curGlobal = self._crossRef.getGlobalByFileNo(fileNo)

--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -4,4 +4,5 @@ reportlab==3.5.23
 xlrd==1.2.0
 winpexpect==1.5
 paramiko==2.4.2
+chardet==3.0.4
 configparser==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ future==0.17.1
 Pillow==6.1.0
 reportlab==3.5.23
 xlrd==1.2.0
+chardet==3.0.4
 pexpect==4.7.0
 paramiko==2.4.2
 configparser==3.5.0


### PR DESCRIPTION
Use the 'chardet' to attempt to determine the charset of an incoming
string instead of assuming it is UTF-8. This should prevent ISO-8859-1
values in VistA from throwing an error.

Also, switch the default encoding type used to be ISO-8859-1

Change-Id: I5fdceaf6123c6c42795c408e3989570ef20e8dec