### PR TITLE
Convert missed exception type

### DIFF
--- a/Testing/UnitTest.py.in
+++ b/Testing/UnitTest.py.in
@@ -15,7 +15,8 @@
 #---------------------------------------------------------------------------
 
 ### set up the IO that is need by unit test
-import sys,os
+import sys
+import os
 sys.path = ['${VISTA_SOURCE_DIR}/Python/vista'] + sys.path
 
 from OSEHRAHelper import ConnectToMUMPS,PROMPT
@@ -25,7 +26,7 @@ if ('${VISTA_CACHE_USERNAME}' and '${VISTA_CACHE_PASSWORD}'):
 if VistA.type=='cache':
   try:
     VistA.ZN('${VISTA_CACHE_NAMESPACE}')
-  except IndexError,no_namechange:
+  except IndexError as no_namechange:
     pass
 
 if '${TEST_VISTA_COVERAGE}'=='ON':


### PR DESCRIPTION
Convert the UNITTEST exception to be the compatible formatting
of "<Exception> as <>" instead of using the comma.

Change-Id: I88e258a3cfeb2053b72280b4d7f61f7eac5be04e