### PR TITLE
Remove winpexpect as it's no longer used

### DIFF
--- a/Python/vista/OSEHRAHelper.py
+++ b/Python/vista/OSEHRAHelper.py
@@ -38,7 +38,6 @@ import telnetlib
 import TestHelper
 import time
 import re
-import pexpect
 import logging
 import csv
 import socket
@@ -52,6 +51,12 @@ try:
   no_paramiko = None
 except ImportError as no_paramiko:
   pass
+
+def isLinuxSystem():
+  return sys.platform.startswith("linux")
+if isLinuxSystem():
+  import pexpect
+  from pexpect import TIMEOUT
 
 def determineEncoding(encString):
   encoding = chardet.detect(encString)['encoding']
@@ -80,6 +85,7 @@ def decode(command):
 # log =False
 
 #---------------------------------------------------------------------------
+
 class PROMPT(object):
   """Wait for a VISTA> prompt in current namespace."""
 

--- a/Scripts/VistATestClient.py
+++ b/Scripts/VistATestClient.py
@@ -32,13 +32,6 @@ def isLinuxSystem():
 def isWindowsSystem():
   return sys.platform.startswith("win")
 
-if isLinuxSystem():
-  import pexpect
-  from pexpect import TIMEOUT, ExceptionPexpect
-else:
-  from pexpect import TIMEOUT
-  from winpexpect import winspawn
-
 OSEHRA_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),"..", "Python", "vista")
 sys.path.append(OSEHRA_DIR)
 from OSEHRAHelper import ConnectWinCache, ConnectLinuxCache, ConnectLinuxGTM
@@ -142,7 +135,7 @@ class VistATestClientGTMLinux(VistATestClient):
                        hostname=DEFAULT_HOST, port=DEFAULT_PORT):
     if not command:
       command = self.DEFAULT_GTM_COMMAND
-    self._connection = ConnectLinuxGTM(self.resfile, instance, self.getPrompt(), "127.0.0.1") # pexpect.spawn(command, timeout = DEFAULT_TIME_OUT_VALUE)
+    self._connection = ConnectLinuxGTM(self.resfile, instance, self.getPrompt(), "127.0.0.1")
     assert self._connection.connection.isalive()
 
 """ common base class for cache test client """

--- a/Testing/pexpectTest.py
+++ b/Testing/pexpectTest.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 #---------------------------------------------------------------------------
 from __future__ import print_function
+import sys
+
 try:
-    import pexpect
+    if sys.platform.startswith("linux"):
+        import pexpect
 except:
     print("No Pexpect")

--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -2,7 +2,6 @@ future==0.17.1
 Pillow==6.1.0
 reportlab==3.5.23
 xlrd==1.2.0
-winpexpect==1.5
 paramiko==2.4.2
 chardet==3.0.4
 configparser==3.5.0


### PR DESCRIPTION
Use the pip installed version of pexpect for Linux systems. For Windows,
neither winpexpect or pexpect are needed.

Fixes #160 and replaces #178.