### PR TITLE
Remove the byte string notation from Git SHA

### DIFF
--- a/Utilities/Dox/PythonScripts/GenerateRepoInfo.py
+++ b/Utilities/Dox/PythonScripts/GenerateRepoInfo.py
@@ -26,7 +26,7 @@ def run(result):
             os.chdir(result.MRepositDir)
             gitCommand = "\"" + result.git + "\"" + " rev-parse --verify HEAD"
             result = subprocess.check_output(gitCommand, shell=True)
-            sha1Key = result.strip()
+            sha1Key = result.strip().decode('ascii')
         else:
             sha1Key = "Non-Git Directory"
         file.write("""{


### PR DESCRIPTION
Remove the b'' used to signify a byte string when printing the SHA1 hash
of the VistA-M repository used by decoding the hash to ASCII

Change-Id: I9aee91707d5171df99b4d48fab9e3e4936b460ae