### PR TITLE
Update RAS test to account for whole month prompt

### DIFF
--- a/Testing/Functional/RAS/lib/ADTActions.py
+++ b/Testing/Functional/RAS/lib/ADTActions.py
@@ -949,7 +949,10 @@ class ADTActions (Actions):
             self.VistA.write('Summary')
             self.VistA.wait('START DATE:')
             self.VistA.write('t-100')
-            self.VistA.wait('END DATE')
+            index = self.VistA.multiwait(['whole month', 'END DATE'])
+            if index == 0:
+                self.VistA.write("N")
+                self.VistA.wait('END DATE')
             self.VistA.write('t')
             self.VistA.wait('DEVICE')
             self.VistA.write('HOME')


### PR DESCRIPTION
Update the RAS test for Registration to account for when "T-100" used in
the Disposition Summary option hits on the 1st of a month.  When that
happens, a new prompt is added before "END DATE" to ask if the
information should be calculated over the "whole month"

https://code.osehra.org/CDash/testDetails.php?test=3243957&build=44202

Say no to that new prompt.

Change-Id: I459d25d02d0cb08337f8c38a66a8f8fb37becdea