### PR TITLE
Update table CSS

### DIFF
--- a/Utilities/Dox/PythonScripts/WebPageGenerator.py
+++ b/Utilities/Dox/PythonScripts/WebPageGenerator.py
@@ -1409,7 +1409,7 @@ class WebPageGenerator(object):
         for (name, values) in propList:
             output += "<li><dl><dt>%s&nbsp;&nbsp;<code>%s</code></dt>" % (name, values[0])
             for value in values[1:]:
-                output += "<dd><pre>%s</pre></dd>" % value
+                output += "<dd><p>%s</p></dd>" % value
             output += "</dl></li>"
         output += "</ul>"
         return output

--- a/Utilities/Dox/Web/DoxygenStyle.css
+++ b/Utilities/Dox/Web/DoxygenStyle.css
@@ -120,6 +120,7 @@ BODY {
 TD.indexkey {
        background-color: #e8eef2;
        font-weight: bold;
+       overflow-wrap: break-word;
        padding-right  : 10px;
        padding-top    : 2px;
        padding-left   : 10px;
@@ -132,6 +133,7 @@ TD.indexkey {
 }
 TD.indexvalue {
        background-color: #e8eef2;
+       overflow-wrap: break-word;
        font-style: italic;
        padding-right  : 10px;
        padding-top    : 2px;
@@ -401,4 +403,8 @@ HR { height: 1px;
     text-decoration: none;
     font-weight: bold;
     color: #1A419D;
+}
+table {
+  table-layout: fixed;
+  width: 100%;
 }


### PR DESCRIPTION
Ensure that the tables are limited to the width of the above div.
Add word-warp values to ensure that long text strings are kept within
the bounds of the table.

Switch from "<pre>" tags to '<p>' to allow the wrapping to be done on
the long field description values,