### PR TITLE
Add pip install of future before platform check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,11 @@ if(TEST_VISTA OR DOCUMENT_VISTA)
   set(VISTA_TCP_HOST "127.0.0.1" CACHE STRING "Server address of the machine that will have the VistA TCP listener")
   set(VISTA_TCP_PORT "9210" CACHE STRING "Port number of the opened TCP listener." )
 
-
+  option(VIRTUAL_ENV "Running in a virtual environment?" OFF)
+  if (NOT ${VIRTUAL_ENV})
+    set(PIP_USER_OPTION "--user")
+  endif()
+  execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-m" "pip" "install" "future" ${PIP_USER_OPTION} RESULT_VARIABLE return OUTPUT_VARIABLE ERROR)
   include(FindCacheOrGTM)
 endif()
 

--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -24,7 +24,6 @@ endif()
 option(TEST_VISTA_XINDEX_WARNINGS_AS_FAILURES "Use warnings as a failure condition for XINDEX tests?" OFF)
 option(TEST_VISTA_FRESH "Overwrite the database file during build phase of testing? To remove this option, delete the CMake Cache" OFF)
 
-option(VIRTUAL_ENV "Running in a virtual environment?" OFF)
 
 #Execute the python script which checks for PExpect
 execute_process(COMMAND "${PYTHON_EXECUTABLE}"  "${CMAKE_CURRENT_SOURCE_DIR}/pexpectTest.py" RESULT_VARIABLE return OUTPUT_VARIABLE ERROR)


### PR DESCRIPTION
Due to the "Python3" transition for the ParseGTMRoutines file,
we need to ensure that the future libraries are found at the start of
the CMake run instead of during the execution of the Testing directory