### PR TITLE
Non-fileman files were potentially displaying data from other files

### DIFF
--- a/Utilities/Dox/PythonScripts/WebPageGenerator.py
+++ b/Utilities/Dox/PythonScripts/WebPageGenerator.py
@@ -967,6 +967,8 @@ class WebPageGenerator(object):
                     if allFields:
                         indexList.append("Fields")
                 else:
+                    fileManDbCallRtns = []
+                    allFields = []
                     indexList = ["Directly Accessed By Routines"]
                 htmlFileName = os.path.join(self._outDir,
                                                getGlobalHtmlFileNameByName(globalName))


### PR DESCRIPTION
For example, sometimes "Directly Accessed By Routines" data would appear on
page but not on the navigation bar. This data was from another fileman file and had not been cleared.

https://issues.osehra.org/browse/VIVIAN-508