### PR TITLE
Update style of tables again

### DIFF
--- a/Utilities/Dox/PythonScripts/WebPageGenerator.py
+++ b/Utilities/Dox/PythonScripts/WebPageGenerator.py
@@ -1411,7 +1411,7 @@ class WebPageGenerator(object):
         for (name, values) in propList:
             output += "<li><dl><dt>%s&nbsp;&nbsp;<code>%s</code></dt>" % (name, values[0])
             for value in values[1:]:
-                output += "<dd><p>%s</p></dd>" % value
+                output += "<dd><code>%s</code></dd>" % value
             output += "</dl></li>"
         output += "</ul>"
         return output

--- a/Utilities/Dox/Web/DoxygenStyle.css
+++ b/Utilities/Dox/Web/DoxygenStyle.css
@@ -406,5 +406,4 @@ HR { height: 1px;
 }
 table {
   table-layout: fixed;
-  width: 100%;
 }


### PR DESCRIPTION
Removing the "width" parameter from the table object in DoxygenStyle.css
allows the table cells to not have equal widths, which we would prefer

Switch from paragraph, "p", objects on subsequent lines of description
to use code objects like the first line.

Change-Id: I95feb4a20496acadd6cfe4fd7c667d3b08224d11