### PR TITLE
Replace open with codecs.open

### DIFF
--- a/Utilities/Dox/PythonScripts/WebPageGenerator.py
+++ b/Utilities/Dox/PythonScripts/WebPageGenerator.py
@@ -1036,7 +1036,7 @@ class WebPageGenerator(object):
                 ]
 
                 filename = os.path.join(self._outDir, getGlobalHtmlFileNameByName(globalName))
-                with open(filename, 'w') as outputFile:
+                with codecs.open(filename, 'w', encoding="ISO-8859-1", errors='ignore') as outputFile:
                     self.__includeHeader__(outputFile)
 
                     icrList = self.queryICRInfo(packageName.upper(), "GLOBAL", globalName[1:])


### PR DESCRIPTION
Additional replacement of .open with codecs.open in WebPageGenerator

Change-Id: Iae885387001a70a5e9541bdf665a64c224ac9218