### PR TITLE
Python 3: Convert M-Unit custom installer in repo

### DIFF
--- a/Testing/Setup/Patches/MUnit/MASH_1.3_0.py
+++ b/Testing/Setup/Patches/MUnit/MASH_1.3_0.py
@@ -1,5 +1,5 @@
 #---------------------------------------------------------------------------
-# Copyright 2015 The Open Source Electronic Health Record Alliance
+# Copyright 2015-2019 The Open Source Electronic Health Record Alliance
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #---------------------------------------------------------------------------
-
+from __future__ import print_function
 from DefaultKIDSBuildInstaller import DefaultKIDSBuildInstaller
 
 """ This is an example of custom installer to handle post install questions
@@ -31,7 +31,7 @@ class CustomInstaller(DefaultKIDSBuildInstaller):
   def __init__(self, kidsFile, kidsInstallName,
                seqNo = None, logFile = None, multiBuildList=None,
                duz=17, **kargs):
-    print kidsInstallName
+    print(kidsInstallName)
     assert kidsInstallName == "MASH*1.3*0"
     DefaultKIDSBuildInstaller.__init__(self, kidsFile,
                                        kidsInstallName,


### PR DESCRIPTION
Convert the Python file used as a custom installer for M-Unit found in
the OSEHRA Testing repository to be Python 3 compatible.

Change-Id: I39cadb1d5b7b1fc646fe73e483a22d821dcc5002