### PR TITLE
Override the default open with codecs.open

### DIFF
--- a/Utilities/Dox/PythonScripts/UtilityFunctions.py
+++ b/Utilities/Dox/PythonScripts/UtilityFunctions.py
@@ -19,6 +19,7 @@ standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from future.utils import iteritems
+import codecs
 import csv
 import json
 import re
@@ -124,6 +125,9 @@ COLOR_MAP = {
 }
 
 ###############################################################################
+
+def cOpen(fileName, openParams):
+  return codecs.open(fileName, openParams, encoding="ISO-8859-1", errors="ignore")
 
 def getDOXURL(local):
     if local:

--- a/Utilities/Dox/PythonScripts/WebPageGenerator.py
+++ b/Utilities/Dox/PythonScripts/WebPageGenerator.py
@@ -54,6 +54,7 @@ from CrossReference import *
 
 from HTMLUtilityFunctions import FOOTER
 from UtilityFunctions import *
+from UtilityFunctions import cOpen as open
 
 # constants
 DEFAULT_OUTPUT_LOG_FILE_NAME = "WebPageGen.log"


### PR DESCRIPTION
Add a UtilityFunction function called cOpen which can be used to override
"open" function in OSEHRA's scripts to utilize "codecs.open" without
needing to change each line.