### PR TITLE
Switch to codecs.encoding in ConvertToExternalData

### DIFF
--- a/Scripts/ConvertToExternalData.py
+++ b/Scripts/ConvertToExternalData.py
@@ -194,7 +194,7 @@ def generateSha1SumCommon(fileObject, buf=1024):
   while True:
     nByte = fileObject.read(buf)
     if nByte:
-      hashString += nByte.encode('ascii')
+      hashString += codecs.encode(nByte, encoding="ascii", errors='ignore')
     else:
       break
   return hashlib.sha1(hashString).hexdigest()


### PR DESCRIPTION
Switch a .encode to a codecs.encode to ignore errors found.
Change is necessary to properly parse the patch found here:

https://foia-vista.osehra.org/Patches%20by%20Year%20and%20Month%20Released/2019/September%202019/LR_52_525.KIDs
Change-Id: Iced2b74034d9e0614f46741e76c50ce744c01886