### PR TITLE
Update .RO line endings

### DIFF
--- a/Scripts/PackRO.py
+++ b/Scripts/PackRO.py
@@ -37,7 +37,7 @@ def pack(files, output):
         m = codecs.open(f,"r", 'ISO-8859-1', 'ignore')
         output.write('%s\n'%n)
         for line in m:
-            output.write(line)
+            output.write('%s\n' % line.rstrip('\n\r'))
         output.write('\n')
     output.write('\n')
     output.write('\n')

--- a/Scripts/UnpackRO.py
+++ b/Scripts/UnpackRO.py
@@ -22,6 +22,7 @@
 import sys
 import codecs
 import os
+import re
 
 def unpack(ro, out=sys.stdout, odir=None):
     # Write out the two header lines for human reference.
@@ -31,7 +32,7 @@ def unpack(ro, out=sys.stdout, odir=None):
     m = None
 
     for line in ro:
-        if line == '\n':
+        if re.match('^[\n\r]+$', line):
             # Routine terminated by blank line
             if m:
                 m.close()


### PR DESCRIPTION
Strip off line endings before writing to .ro
Ensure that only a single return is used for at the end of each line of
code added for the creation of the .ro file.

When looking for a blank line in .ro, strip off the '\n\r' and look for
an empty string.

Change-Id: I267d933ba987ec82d27828780f0ec74f26c53a41