### PR TITLE
Fix "Show more entries" link logic

### DIFF
--- a/Utilities/Dox/PythonScripts/WebPageGenerator.py
+++ b/Utilities/Dox/PythonScripts/WebPageGenerator.py
@@ -2556,9 +2556,10 @@ class WebPageGenerator(object):
                 outputFile.write("</tr>\n")
                 if self._generatePDFBundle and pdfRow:
                     pdfTable.append(pdfRow)
-                if objectCount > 1000:
-                    outputFile.write("<tr><td colspan=\"%s\">For the entire list of entries see: <a href=\"%s\">Here</a></td></tr>" % (totalCol, additionalDetailsURL) )
-                    break
+                if  additionalDetailsURL != "":
+                    if (objectCount > 1000):
+                        outputFile.write("<tr><td colspan=\"%s\">For the entire list of entries see: <a href=\"%s\">Here</a></td></tr>" % (totalCol, additionalDetailsURL) )
+                        break
             outputFile.write("</table>\n</div>\n")
         else:
             outputFile.write("<div>\n</div>\n")


### PR DESCRIPTION
Ensure that only pages that supply an "additionalDetailsURL" link that shrinks the large amount of objects with the message to see the rest on an additional page.

This will prevent long lists of routines from being truncated, as is the case with the Integrated Billing package.