### PR TITLE
Fix GraphGen naming of images in DOX

### DIFF
--- a/Utilities/Dox/PythonScripts/GraphGenerator.py
+++ b/Utilities/Dox/PythonScripts/GraphGenerator.py
@@ -226,11 +226,11 @@ class GraphGenerator(object):
             routineSuffix = "called"
         else:
             routineSuffix = "caller"
-        fileNameRoot = os.path.join(dirName, "%s_%s" % (normalizedName, routineSuffix))
+        routineType = routine.getObjectType()
+        fileNameRoot = os.path.join(dirName, "%s_%s_%s" % (routineType, normalizedName, routineSuffix))
         dotFilename = "%s.dot" % fileNameRoot
         pngFilename = "%s.png" % fileNameRoot
         cmapxFilename = "%s.cmapx" % fileNameRoot
-
         with open(dotFilename, 'w') as output:
             escapedName = re.escape(routineName)
             output.write("digraph \"%s\" {\n" % fileNameRoot)
@@ -240,7 +240,7 @@ class GraphGenerator(object):
     #        output.write("\tedge [fontsize=12];\n") # set the edge label and size props
             if package not in depRoutines:
                 output.write("\tsubgraph \"cluster_%s\"{\n" % package)
-                output.write("\t\t\"%s\" [style=filled fillcolor=orange];\n" % escapedName)
+                output.write("\t\t\"%s\" [id='main' style=filled fillcolor=orange];\n" % escapedName)
                 output.write("\t}\n")
 
             for (depPackage, callDict) in iteritems(depRoutines):

--- a/Utilities/Dox/PythonScripts/WebPageGenerator.py
+++ b/Utilities/Dox/PythonScripts/WebPageGenerator.py
@@ -3272,7 +3272,7 @@ class WebPageGenerator(object):
         else:
             routineSuffix = "caller"
         normalizedRoutineName = normalizeName(routineName)
-        fileNamePrefix = "%s_%s" % (normalizedRoutineName, routineSuffix)
+        fileNamePrefix = "%s_%s_%s" % (routine.getObjectType(), normalizedRoutineName, routineSuffix)
         fileName = os.path.join(self._outDir, packageName, fileNamePrefix + ".cmapx")
         try:
             # append the content of map outputFile


### PR DESCRIPTION
Append the "ObjectType" parameter to the generated images of DOX in both
the GraphGenerator and WebPageGenerator.  This will prevent objects
like "Routine_LRBLA" and "Option_LRBLA" from colliding the callergraph
images, which would be originally saved as "LRBLA_caller.png" for both objects.