### PR TITLE
Add XINDEX exceptions for Nov 2019

### DIFF
--- a/Packages/Kernel/XINDEXException/GTM.XULMRPC
+++ b/Packages/Kernel/XINDEXException/GTM.XULMRPC
@@ -1,0 +1,1 @@
+KILLPROC+12  F - Reference to routine '^%ZLMLIB'. That isn't in this UCI.

--- a/Packages/Kernel/XINDEXException/GTM.XULMU
+++ b/Packages/Kernel/XINDEXException/GTM.XULMU
@@ -1,0 +1,3 @@
+GETLOCKS+9   F - Reference to routine '^%ZLMLIB'. That isn't in this UCI.
+OWNER+6      F - Reference to routine '^%ZLMLIB'. That isn't in this UCI.
+GETLOCKS+6   F - Reference to routine '^%ZLMLIB'. That isn't in this UCI.

--- a/Packages/Mental Health/XINDEXException/GTM.YTSBBHI2
+++ b/Packages/Mental Health/XINDEXException/GTM.YTSBBHI2
@@ -1,0 +1,1 @@
+EXP+1        F - Reference to routine '^XTFN'. That isn't in this UCI.


### PR DESCRIPTION
Add the execptions for the XINDEX errors which were new in the
OSEHRA VistA update for November 2019