### PR TITLE
Ensure last global found is added to list

### DIFF
--- a/Scripts/GitUtils.py
+++ b/Scripts/GitUtils.py
@@ -138,6 +138,9 @@ def addChangeSet(gitRepoDir=None, patternList=[]):
             outLineStack.pop(0)
         else:
           results.append("OK")
+    # Ensure that the last object is captured, if necessary
+    if ("OK" in results) or len(outLineStack):
+      patternIncludeList.append(currentFile)
   """ Now add everything that can be found or was called for"""
   git_command_list = ["git", "add", "--"]
   totalIncludeList = patternList + patternIncludeList


### PR DESCRIPTION
Ensure that as the loop over the DIFF text exits, the last global is
checked for content.  Currently, the changes to the last Global or any
package with a single global are ignored.

Change-Id: Ia02c62fef994266bf7526e70f41cc508510c57ac