### PR TITLE
Change "Found Entries" to sort by IEN

### DIFF
--- a/Utilities/Dox/PythonScripts/WebPageGenerator.py
+++ b/Utilities/Dox/PythonScripts/WebPageGenerator.py
@@ -1185,7 +1185,7 @@ class WebPageGenerator(object):
                       self.writeSectionHeader("Found Entries, Total: %d" % len(entryList),
                                               "Found Entries", outputFile, pdf,
                                               useAccordion)
-                      self.generateTablizedItemList(sorted(entryList, key=lambda x: self.getGlobalEntryName(x)),
+                      self.generateTablizedItemList(sorted(entryList, key=lambda x: float(x['IENum'])),
                                                     outputFile,
                                                     self.getGlobalEntryHTML,
                                                     nameFunc=self.getGlobalEntryName,


### PR DESCRIPTION
Change the sorting parameter for "Found Entries" to be the Internal
Entry number of the object instead of the name.

Change-Id: I0cb82e9331cd4b87d19389c69b9a03861a9b2aeb