### PR TITLE
Make 0 an acceptable index

### DIFF
--- a/Scripts/DefaultKIDSBuildInstaller.py
+++ b/Scripts/DefaultKIDSBuildInstaller.py
@@ -184,7 +184,7 @@ class DefaultKIDSBuildInstaller(object):
     kidsMenuActionLst = self.KIDS_MENU_OPTION_ACTION_LIST
     while True:
       index = connection.expect([x[0] for x in kidsMenuActionLst])
-      if index > 0:
+      if index >= 0:
         sendCmd = kidsMenuActionLst[index][1]
         if sendCmd != None:
           connection.send("%s\r" % sendCmd)


### PR DESCRIPTION
Searching for > 0 causes the first option to never be utilized
correctly.  The XOB*1.6*3 patch requires the "want to continue" message
to be found and properly answered.

Change-Id: I2c55bf23a6e2567d4467466549e15537b6eb68b5